### PR TITLE
test: add test infrastructure and initial test suite (47 tests)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,16 @@ dependencies = [
     "mcp[cli]>=1.9.2",
     "okta>=2.9.13",
     "requests>=2.32.4",
-    "ruff>=0.11.13",
     "keyring>=25.6.0",
-    "keyrings.alt>=5.0.0"
+    "keyrings.alt>=5.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.11.13",
 ]
 
 [build-system]
@@ -23,3 +30,14 @@ packages = ["src/okta_mcp_server"]
 
 [project.scripts]
 okta-mcp-server = "okta_mcp_server:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["okta_mcp_server"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true

--- a/tests/test_auth_manager.py
+++ b/tests/test_auth_manager.py
@@ -1,0 +1,232 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for okta_mcp_server.utils.auth.auth_manager"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from okta_mcp_server.utils.auth.auth_manager import OktaAuthManager, SERVICE_NAME
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_vars(monkeypatch):
+    """Set required env vars for OktaAuthManager."""
+    monkeypatch.setenv("OKTA_ORG_URL", "https://dev-123456.okta.com")
+    monkeypatch.setenv("OKTA_CLIENT_ID", "0oa1abcdef")
+    # Clear optional browserless vars
+    monkeypatch.delenv("OKTA_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("OKTA_KEY_ID", raising=False)
+    monkeypatch.delenv("OKTA_SCOPES", raising=False)
+
+
+@pytest.fixture
+def browserless_env(monkeypatch, env_vars):
+    """Set env vars for browserless auth."""
+    monkeypatch.setenv("OKTA_PRIVATE_KEY", "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----")
+    monkeypatch.setenv("OKTA_KEY_ID", "kid123")
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestOktaAuthManagerInit:
+    def test_init_with_required_vars(self, env_vars):
+        manager = OktaAuthManager()
+        assert manager.org_url == "https://dev-123456.okta.com"
+        assert manager.client_id == "0oa1abcdef"
+        assert manager.use_browserless_auth is False
+
+    def test_adds_https_prefix(self, monkeypatch):
+        monkeypatch.setenv("OKTA_ORG_URL", "dev-123456.okta.com")
+        monkeypatch.setenv("OKTA_CLIENT_ID", "0oa1abcdef")
+        manager = OktaAuthManager()
+        assert manager.org_url == "https://dev-123456.okta.com"
+
+    def test_exits_without_org_url(self, monkeypatch):
+        monkeypatch.delenv("OKTA_ORG_URL", raising=False)
+        monkeypatch.setenv("OKTA_CLIENT_ID", "0oa1abcdef")
+        with pytest.raises(SystemExit):
+            OktaAuthManager()
+
+    def test_exits_without_client_id(self, monkeypatch):
+        monkeypatch.setenv("OKTA_ORG_URL", "https://dev.okta.com")
+        monkeypatch.delenv("OKTA_CLIENT_ID", raising=False)
+        with pytest.raises(SystemExit):
+            OktaAuthManager()
+
+    def test_browserless_auth_detected(self, browserless_env):
+        manager = OktaAuthManager()
+        assert manager.use_browserless_auth is True
+
+    def test_private_key_without_key_id_falls_back(self, monkeypatch, env_vars):
+        monkeypatch.setenv("OKTA_PRIVATE_KEY", "somekey")
+        monkeypatch.delenv("OKTA_KEY_ID", raising=False)
+        manager = OktaAuthManager()
+        assert manager.use_browserless_auth is False
+
+    def test_custom_scopes(self, monkeypatch, env_vars):
+        monkeypatch.setenv("OKTA_SCOPES", "okta.users.read")
+        manager = OktaAuthManager()
+        assert "okta.users.read" in manager.scopes
+
+    def test_private_key_newline_processing(self, monkeypatch, env_vars):
+        monkeypatch.setenv("OKTA_PRIVATE_KEY", "line1\\nline2")
+        monkeypatch.setenv("OKTA_KEY_ID", "kid123")
+        manager = OktaAuthManager()
+        assert "\n" in manager.private_key
+        assert "\\n" not in manager.private_key
+
+
+# ---------------------------------------------------------------------------
+# Token validation
+# ---------------------------------------------------------------------------
+
+
+class TestIsValidToken:
+    async def test_valid_token(self, env_vars):
+        manager = OktaAuthManager()
+        manager.token_timestamp = int(time.time())
+
+        with patch("keyring.get_password", return_value="valid_token"):
+            assert await manager.is_valid_token() is True
+
+    async def test_expired_token_triggers_refresh(self, env_vars):
+        manager = OktaAuthManager()
+        manager.token_timestamp = int(time.time()) - 7200  # 2 hours ago
+
+        with (
+            patch("keyring.get_password", return_value="old_token"),
+            patch.object(manager, "refresh_access_token", return_value=True) as mock_refresh,
+        ):
+            await manager.is_valid_token()
+            mock_refresh.assert_called_once()
+
+    async def test_missing_token(self, env_vars):
+        manager = OktaAuthManager()
+        manager.token_timestamp = 0
+
+        with (
+            patch("keyring.get_password", return_value=None),
+            patch.object(manager, "refresh_access_token", return_value=False),
+            patch.object(manager, "authenticate", new_callable=AsyncMock) as mock_auth,
+        ):
+            await manager.is_valid_token()
+            mock_auth.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Token refresh
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshAccessToken:
+    def test_no_refresh_token(self, env_vars):
+        manager = OktaAuthManager()
+        with patch("keyring.get_password", return_value=None):
+            assert manager.refresh_access_token() is False
+
+    def test_successful_refresh(self, env_vars):
+        manager = OktaAuthManager()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "new_token",
+            "refresh_token": "new_refresh",
+        }
+
+        with (
+            patch("keyring.get_password", return_value="old_refresh_token"),
+            patch("keyring.set_password") as mock_set,
+            patch("requests.post", return_value=mock_response),
+        ):
+            assert manager.refresh_access_token() is True
+            assert mock_set.call_count == 2  # access + refresh
+
+    def test_failed_refresh(self, env_vars):
+        manager = OktaAuthManager()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "invalid_grant"
+
+        with (
+            patch("keyring.get_password", return_value="old_refresh"),
+            patch("requests.post", return_value=mock_response),
+        ):
+            assert manager.refresh_access_token() is False
+
+
+# ---------------------------------------------------------------------------
+# Clear tokens
+# ---------------------------------------------------------------------------
+
+
+class TestClearTokens:
+    def test_clears_all_tokens(self, env_vars):
+        manager = OktaAuthManager()
+        manager.token_timestamp = 12345
+
+        with patch("keyring.delete_password") as mock_delete:
+            manager.clear_tokens()
+            assert mock_delete.call_count == 2
+            assert manager.token_timestamp == 0
+
+    def test_handles_keyring_errors(self, env_vars):
+        from keyring.errors import KeyringError
+
+        manager = OktaAuthManager()
+
+        with patch(
+            "keyring.delete_password",
+            side_effect=KeyringError("not found"),
+        ):
+            # Should not raise
+            manager.clear_tokens()
+            assert manager.token_timestamp == 0
+
+
+# ---------------------------------------------------------------------------
+# Device authorization
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceAuthorization:
+    def test_initiate_device_authorization_success(self, env_vars):
+        manager = OktaAuthManager()
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "device_code": "dc_123",
+            "user_code": "ABCD-EFGH",
+            "verification_uri_complete": "https://dev.okta.com/activate?user_code=ABCD",
+            "expires_in": 600,
+            "interval": 5,
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("requests.post", return_value=mock_response):
+            result = manager._initiate_device_authorization()
+            assert result["device_code"] == "dc_123"
+            assert "start_time" in result
+
+    def test_initiate_device_authorization_failure_exits(self, env_vars):
+        import requests as req
+
+        manager = OktaAuthManager()
+
+        with patch("requests.post", side_effect=req.RequestException("fail")):
+            with pytest.raises(SystemExit):
+                manager._initiate_device_authorization()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,60 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for okta_mcp_server.utils.client"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from okta_mcp_server.utils.auth.auth_manager import OktaAuthManager
+
+
+# We need to mock okta.client.Client since it may not be installed
+@pytest.fixture
+def mock_okta_client():
+    with patch.dict(
+        "sys.modules",
+        {
+            "okta": MagicMock(),
+            "okta.client": MagicMock(),
+        },
+    ):
+        from okta_mcp_server.utils.client import get_okta_client
+
+        yield get_okta_client
+
+
+class TestGetOktaClient:
+    async def test_creates_client_with_valid_token(self, mock_okta_client, monkeypatch):
+        monkeypatch.setenv("OKTA_ORG_URL", "https://dev.okta.com")
+        monkeypatch.setenv("OKTA_CLIENT_ID", "client123")
+
+        manager = OktaAuthManager()
+        manager.org_url = "https://dev.okta.com"
+
+        with (
+            patch("keyring.get_password", return_value="valid_api_token"),
+            patch.object(manager, "is_valid_token", new_callable=AsyncMock, return_value=True),
+        ):
+            client = await mock_okta_client(manager)
+            assert client is not None
+
+    async def test_reauthenticates_on_invalid_token(self, mock_okta_client, monkeypatch):
+        monkeypatch.setenv("OKTA_ORG_URL", "https://dev.okta.com")
+        monkeypatch.setenv("OKTA_CLIENT_ID", "client123")
+
+        manager = OktaAuthManager()
+        manager.org_url = "https://dev.okta.com"
+
+        with (
+            patch("keyring.get_password", return_value="new_token"),
+            patch.object(manager, "is_valid_token", new_callable=AsyncMock, return_value=False),
+            patch.object(manager, "authenticate", new_callable=AsyncMock) as mock_auth,
+        ):
+            client = await mock_okta_client(manager)
+            mock_auth.assert_called_once()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,254 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for okta_mcp_server.utils.pagination"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from okta_mcp_server.utils.pagination import (
+    build_query_params,
+    create_paginated_response,
+    extract_after_cursor,
+    paginate_all_results,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(has_next: bool = False, next_url: str | None = None):
+    """Create a mock OktaAPIResponse."""
+    resp = MagicMock()
+    resp.has_next.return_value = has_next
+    resp._next = next_url
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# extract_after_cursor
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAfterCursor:
+    def test_returns_none_for_none_response(self):
+        assert extract_after_cursor(None) is None
+
+    def test_returns_none_when_no_has_next(self):
+        resp = MagicMock(spec=[])  # no has_next attr
+        assert extract_after_cursor(resp) is None
+
+    def test_returns_none_when_has_next_false(self):
+        resp = _mock_response(has_next=False)
+        assert extract_after_cursor(resp) is None
+
+    def test_extracts_cursor_from_next_url(self):
+        resp = _mock_response(
+            has_next=True,
+            next_url="/api/v1/users?after=00u1abc123&limit=200",
+        )
+        assert extract_after_cursor(resp) == "00u1abc123"
+
+    def test_returns_none_when_no_after_param(self):
+        resp = _mock_response(
+            has_next=True,
+            next_url="/api/v1/users?limit=200",
+        )
+        assert extract_after_cursor(resp) is None
+
+    def test_returns_none_when_next_is_none(self):
+        resp = _mock_response(has_next=True, next_url=None)
+        assert extract_after_cursor(resp) is None
+
+    def test_handles_malformed_url_gracefully(self):
+        resp = _mock_response(has_next=True, next_url="not-a-url")
+        # Should not raise
+        result = extract_after_cursor(resp)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# build_query_params
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQueryParams:
+    def test_empty_params(self):
+        assert build_query_params() == {}
+
+    def test_search_only(self):
+        result = build_query_params(search='profile.email eq "a@b.com"')
+        assert result == {"search": 'profile.email eq "a@b.com"'}
+
+    def test_all_params(self):
+        result = build_query_params(
+            search="s",
+            filter="f",
+            q="q",
+            after="cursor123",
+            limit=50,
+        )
+        assert result == {
+            "search": "s",
+            "filter": "f",
+            "q": "q",
+            "after": "cursor123",
+            "limit": "50",
+        }
+
+    def test_empty_strings_excluded(self):
+        result = build_query_params(search="", filter=None, q=None)
+        assert result == {}
+
+    def test_kwargs_forwarded(self):
+        result = build_query_params(since="2024-01-01", until="2024-02-01")
+        assert result == {"since": "2024-01-01", "until": "2024-02-01"}
+
+    def test_kwargs_none_excluded(self):
+        result = build_query_params(since=None)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# create_paginated_response
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePaginatedResponse:
+    def test_basic_response_structure(self):
+        resp = _mock_response(has_next=False)
+        result = create_paginated_response(["item1", "item2"], resp)
+        assert result["items"] == ["item1", "item2"]
+        assert result["total_fetched"] == 2
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+        assert result["fetch_all_used"] is False
+
+    def test_has_more_with_cursor(self):
+        resp = _mock_response(
+            has_next=True,
+            next_url="/api/v1/users?after=abc123",
+        )
+        result = create_paginated_response(["item"], resp)
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "abc123"
+
+    def test_fetch_all_used_skips_cursor(self):
+        resp = _mock_response(has_next=True)
+        result = create_paginated_response(
+            ["item"], resp, fetch_all_used=True
+        )
+        assert result["fetch_all_used"] is True
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+
+    def test_empty_items(self):
+        resp = _mock_response()
+        result = create_paginated_response([], resp)
+        assert result["total_fetched"] == 0
+        assert result["items"] == []
+
+    def test_pagination_info_included(self):
+        resp = _mock_response()
+        info = {"pages_fetched": 3, "total_items": 150}
+        result = create_paginated_response(
+            ["item"], resp, pagination_info=info
+        )
+        assert result["pagination_info"] == info
+
+    def test_none_response(self):
+        result = create_paginated_response(["item"], None)
+        assert result["has_more"] is False
+
+
+# ---------------------------------------------------------------------------
+# paginate_all_results
+# ---------------------------------------------------------------------------
+
+
+class TestPaginateAllResults:
+    async def test_single_page_no_next(self):
+        resp = _mock_response(has_next=False)
+        items, info = await paginate_all_results(resp, ["a", "b"])
+        assert items == ["a", "b"]
+        assert info["pages_fetched"] == 1
+        assert info["total_items"] == 2
+        assert info["stopped_early"] is False
+
+    async def test_multi_page(self):
+        page2_resp = _mock_response(has_next=False)
+        resp = _mock_response(has_next=True)
+        resp.next = AsyncMock(return_value=(["c", "d"], None))
+        # After first .next() call, has_next should return False
+        resp.has_next.side_effect = [True, False]
+
+        items, info = await paginate_all_results(
+            resp, ["a", "b"], delay_between_requests=0
+        )
+        assert items == ["a", "b", "c", "d"]
+        assert info["pages_fetched"] == 2
+        assert info["total_items"] == 4
+
+    async def test_max_pages_limit(self):
+        resp = _mock_response(has_next=True)
+        resp.next = AsyncMock(return_value=(["x"], None))
+        # Always has_next = True to trigger max_pages
+        resp.has_next.return_value = True
+
+        items, info = await paginate_all_results(
+            resp, ["a"], max_pages=3, delay_between_requests=0
+        )
+        assert info["pages_fetched"] == 3
+        assert info["stopped_early"] is True
+        assert "maximum page limit" in info["stop_reason"]
+
+    async def test_error_on_next_page(self):
+        resp = _mock_response(has_next=True)
+        resp.has_next.side_effect = [True, False]
+        resp.next = AsyncMock(return_value=(None, "API error"))
+
+        items, info = await paginate_all_results(
+            resp, ["a"], delay_between_requests=0
+        )
+        assert items == ["a"]
+        assert info["stopped_early"] is True
+        assert "API error" in info["stop_reason"]
+
+    async def test_exception_during_pagination(self):
+        resp = _mock_response(has_next=True)
+        resp.has_next.side_effect = [True, False]
+        resp.next = AsyncMock(side_effect=RuntimeError("network"))
+
+        items, info = await paginate_all_results(
+            resp, ["a"], delay_between_requests=0
+        )
+        assert items == ["a"]
+        assert info["stopped_early"] is True
+
+    async def test_none_response(self):
+        items, info = await paginate_all_results(None, ["a"])
+        assert items == ["a"]
+        assert info["pages_fetched"] == 1
+
+    async def test_response_without_has_next(self):
+        resp = MagicMock(spec=[])  # no has_next
+        items, info = await paginate_all_results(resp, ["a"])
+        assert items == ["a"]
+
+    async def test_empty_next_page_stops(self):
+        resp = _mock_response(has_next=True)
+        resp.has_next.side_effect = [True, False]
+        resp.next = AsyncMock(return_value=([], None))
+
+        items, info = await paginate_all_results(
+            resp, ["a"], delay_between_requests=0
+        )
+        assert items == ["a"]


### PR DESCRIPTION
## Summary

- Add `pytest`, `pytest-asyncio`, and `pytest-cov` as dev dependencies with test configuration in `pyproject.toml`
- Move `ruff` from runtime `dependencies` to `[dev]` optional dependencies (it's a development tool, not needed by end users at runtime)
- Add **47 tests** covering the utility layer:
  - `pagination.py`: `extract_after_cursor`, `build_query_params`, `create_paginated_response`, `paginate_all_results` (27 tests)
  - `auth_manager.py`: initialization, token validation, token refresh, clear tokens, device authorization (18 tests)
  - `client.py`: `get_okta_client` with valid/invalid tokens (2 tests)

All tests mock external dependencies (Okta SDK, keyring, requests) — no real API calls needed.

## Test plan

- [x] `pytest tests/ -v` passes (47/47)
- [ ] Verify tests pass in CI (Python 3.13)
- [ ] Verify `ruff` removal from runtime deps doesn't affect installation