### PR TITLE
fix: standardize MCP response format to JSON-serializable dicts

### DIFF
--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
+from okta_mcp_server.utils.serialization import serialize
 
 
 @mcp.tool()
@@ -81,10 +82,10 @@ async def list_applications(
             return []
 
         logger.info(f"Successfully retrieved {len(apps)} applications")
-        return [app for app in apps]
+        return [serialize(app) for app in apps]
     except Exception as e:
         logger.error(f"Exception while listing applications: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return {"error": f"Exception: {e}"}
 
 
 @mcp.tool()
@@ -117,7 +118,7 @@ async def get_application(ctx: Context, app_id: str, expand: Optional[str] = Non
             return {"error": str(err)}
 
         logger.info(f"Successfully retrieved application: {app_id}")
-        return app
+        return serialize(app)
     except Exception as e:
         logger.error(f"Exception while getting application {app_id}: {type(e).__name__}: {e}")
         return {"error": str(e)}
@@ -151,8 +152,8 @@ async def create_application(ctx: Context, app_config: Dict[str, Any], activate:
             logger.error(f"Okta API error while creating application: {err}")
             return {"error": str(err)}
 
-        logger.info(f"Successfully created application")
-        return app
+        logger.info("Successfully created application")
+        return serialize(app)
     except Exception as e:
         logger.error(f"Exception while creating application: {type(e).__name__}: {e}")
         return {"error": str(e)}
@@ -184,7 +185,7 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
             return {"error": str(err)}
 
         logger.info(f"Successfully updated application: {app_id}")
-        return app
+        return serialize(app)
     except Exception as e:
         logger.error(f"Exception while updating application {app_id}: {type(e).__name__}: {e}")
         return {"error": str(e)}

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.serialization import serialize
 
 
 @mcp.tool()
@@ -129,10 +130,10 @@ async def get_group(group_id: str, ctx: Context = None) -> list:
             return {"error": f"Error: {err}"}
 
         logger.info(f"Successfully retrieved group: {group_id}")
-        return [group]
+        return serialize(group)
     except Exception as e:
         logger.error(f"Exception while getting group {group_id}: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return {"error": f"Exception: {e}"}
 
 
 @mcp.tool()
@@ -166,10 +167,10 @@ async def create_group(profile: dict, ctx: Context = None) -> list:
         logger.info(
             f"Successfully created group: {group.id} ({group.profile.name if hasattr(group, 'profile') else 'N/A'})"
         )
-        return [group]
+        return serialize(group)
     except Exception as e:
         logger.error(f"Exception while creating group: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return {"error": f"Exception: {e}"}
 
 
 @mcp.tool()
@@ -272,10 +273,10 @@ async def update_group(group_id: str, profile: dict, ctx: Context = None) -> lis
             return {"error": f"Error: {err}"}
 
         logger.info(f"Successfully updated group: {group_id}")
-        return [group]
+        return serialize(group)
     except Exception as e:
         logger.error(f"Exception while updating group {group_id}: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return {"error": f"Exception: {e}"}
 
 
 @mcp.tool()
@@ -387,10 +388,10 @@ async def list_group_apps(group_id: str, ctx: Context = None) -> list:
         app_count = len(apps) if apps else 0
         logger.info(f"Successfully retrieved {app_count} applications for group {group_id}")
 
-        return [app for app in apps]
+        return [serialize(app) for app in apps]
     except Exception as e:
         logger.error(f"Exception while listing applications for group {group_id}: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return {"error": f"Exception: {e}"}
 
 
 @mcp.tool()

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
+from okta_mcp_server.utils.serialization import serialize
 
 
 @mcp.tool()
@@ -76,7 +77,7 @@ async def list_policies(
 
         logger.info(f"Successfully retrieved {len(policies)} policies")
         return {
-            "policies": [policy.as_dict() for policy in policies],
+            "policies": [serialize(policy) for policy in policies],
         }
 
     except Exception as e:
@@ -104,7 +105,7 @@ async def get_policy(ctx: Context, policy_id: str) -> Optional[Dict[str, Any]]:
             logger.error(f"Error getting policy {policy_id}: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return serialize(policy) if policy else None
 
     except Exception as e:
         logger.error(f"Exception getting policy: {e}")
@@ -139,7 +140,7 @@ async def create_policy(ctx: Context, policy_data: Dict[str, Any]) -> Optional[D
             logger.error(f"Error creating policy: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return serialize(policy) if policy else None
 
     except Exception as e:
         logger.error(f"Exception creating policy: {e}")
@@ -167,7 +168,7 @@ async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any
             logger.error(f"Error updating policy {policy_id}: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return serialize(policy) if policy else None
 
     except Exception as e:
         logger.error(f"Exception updating policy: {e}")
@@ -284,7 +285,7 @@ async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
             return {"rules": []}
 
         return {
-            "rules": [rule.as_dict() for rule in rules],
+            "rules": [serialize(rule) for rule in rules],
             "has_next": resp.has_next() if resp else False,
             "next_page_token": resp.get_next_page_token() if resp and resp.has_next() else None,
         }
@@ -315,7 +316,7 @@ async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optiona
             logger.error(f"Error getting policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return serialize(rule) if rule else None
 
     except Exception as e:
         logger.error(f"Exception getting policy rule: {e}")
@@ -348,7 +349,7 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
             logger.error(f"Error creating policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return serialize(rule) if rule else None
 
     except Exception as e:
         logger.error(f"Exception creating policy rule: {e}")
@@ -379,7 +380,7 @@ async def update_policy_rule(
             logger.error(f"Error updating policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return serialize(rule) if rule else None
 
     except Exception as e:
         logger.error(f"Exception updating policy rule: {e}")

--- a/src/okta_mcp_server/utils/serialization.py
+++ b/src/okta_mcp_server/utils/serialization.py
@@ -1,0 +1,73 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Serialization utilities for converting Okta SDK objects to JSON-safe dicts.
+
+The Okta SDK returns objects that are not JSON-serializable:
+- Enum values render as ``<ApplicationSignOnMode.SAML_2_0: 'SAML_2_0'>``
+- ``OktaAPIResponse`` objects render as ``<okta.api_response... at 0x...>``
+- Some objects expose ``.as_dict()`` while others only have ``.__dict__``
+
+This module provides a single ``serialize`` function that handles all cases
+and returns clean JSON-serializable Python dicts/lists.
+"""
+
+from enum import Enum
+from typing import Any
+
+
+def serialize(obj: Any) -> Any:
+    """Convert an Okta SDK object to a JSON-serializable value.
+
+    Handles SDK model objects, enums, nested structures, and edge cases.
+    Returns plain dicts, lists, strings, numbers, booleans, and None.
+
+    Args:
+        obj: Any value returned by the Okta SDK.
+
+    Returns:
+        A JSON-serializable Python value.
+    """
+    if obj is None:
+        return None
+
+    # Primitives pass through
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+
+    # Enums → their string value
+    if isinstance(obj, Enum):
+        return obj.value
+
+    # Dicts → recurse on values
+    if isinstance(obj, dict):
+        return {str(k): serialize(v) for k, v in obj.items()}
+
+    # Lists/tuples → recurse on elements
+    if isinstance(obj, (list, tuple)):
+        return [serialize(item) for item in obj]
+
+    # SDK objects with .as_dict()
+    if hasattr(obj, "as_dict"):
+        try:
+            return serialize(obj.as_dict())
+        except Exception:
+            pass
+
+    # Objects with __dict__ (SDK model instances)
+    if hasattr(obj, "__dict__"):
+        result = {}
+        for key, value in obj.__dict__.items():
+            # Skip private/internal attributes
+            if key.startswith("_"):
+                continue
+            result[key] = serialize(value)
+        if result:
+            return result
+
+    # Fallback: string representation
+    return str(obj)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,262 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for okta_mcp_server.utils.serialization"""
+
+import json
+from enum import Enum
+
+import pytest
+
+from okta_mcp_server.utils.serialization import serialize
+
+
+# ---------------------------------------------------------------------------
+# Mock SDK objects (simulating Okta SDK model behavior)
+# ---------------------------------------------------------------------------
+
+
+class MockSignOnMode(Enum):
+    SAML_2_0 = "SAML_2_0"
+    OPENID_CONNECT = "OPENID_CONNECT"
+    BROWSER_PLUGIN = "BROWSER_PLUGIN"
+
+
+class MockUserStatus(Enum):
+    ACTIVE = "ACTIVE"
+    LOCKED_OUT = "LOCKED_OUT"
+    DEPROVISIONED = "DEPROVISIONED"
+
+
+class MockProfile:
+    """Simulates an Okta user/app profile object."""
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class MockApplication:
+    """Simulates an Okta Application SDK object."""
+
+    def __init__(self):
+        self.id = "0oa1abc123"
+        self.name = "My SAML App"
+        self.label = "My SAML App"
+        self.status = MockUserStatus.ACTIVE
+        self.sign_on_mode = MockSignOnMode.SAML_2_0
+        self._links = {"self": "https://dev.okta.com/api/v1/apps/0oa1abc123"}
+        self._private_internal = "should be hidden"
+
+
+class MockApplicationWithAsDict:
+    """Simulates an Okta object that has .as_dict()."""
+
+    def __init__(self):
+        self.id = "0oa1abc123"
+        self._internal = "hidden"
+
+    def as_dict(self):
+        return {
+            "id": self.id,
+            "name": "App via as_dict",
+            "signOnMode": "SAML_2_0",
+        }
+
+
+class MockUser:
+    """Simulates an Okta User SDK object."""
+
+    def __init__(self):
+        self.id = "00u1xyz789"
+        self.status = MockUserStatus.ACTIVE
+        self.profile = MockProfile(
+            email="user@example.com",
+            firstName="John",
+            lastName="Doe",
+            login="user@example.com",
+        )
+        self._embedded = {"some": "data"}
+
+
+class MockOktaAPIResponse:
+    """Simulates the raw OktaAPIResponse object that has no useful serialization."""
+
+    def __init__(self):
+        self._url = "https://dev.okta.com/api/v1/users"
+        self._status = 200
+        self._headers = {}
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+class TestSerializePrimitives:
+    def test_none(self):
+        assert serialize(None) is None
+
+    def test_string(self):
+        assert serialize("hello") == "hello"
+
+    def test_int(self):
+        assert serialize(42) == 42
+
+    def test_float(self):
+        assert serialize(3.14) == 3.14
+
+    def test_bool(self):
+        assert serialize(True) is True
+        assert serialize(False) is False
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeEnums:
+    def test_enum_value(self):
+        assert serialize(MockSignOnMode.SAML_2_0) == "SAML_2_0"
+
+    def test_enum_in_dict(self):
+        result = serialize({"mode": MockSignOnMode.OPENID_CONNECT})
+        assert result == {"mode": "OPENID_CONNECT"}
+
+    def test_enum_in_list(self):
+        result = serialize([MockUserStatus.ACTIVE, MockUserStatus.LOCKED_OUT])
+        assert result == ["ACTIVE", "LOCKED_OUT"]
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeCollections:
+    def test_dict(self):
+        result = serialize({"a": 1, "b": "two"})
+        assert result == {"a": 1, "b": "two"}
+
+    def test_nested_dict(self):
+        result = serialize({"outer": {"inner": "value"}})
+        assert result == {"outer": {"inner": "value"}}
+
+    def test_list(self):
+        result = serialize([1, "two", 3.0])
+        assert result == [1, "two", 3.0]
+
+    def test_tuple_converted_to_list(self):
+        result = serialize(("a", "b", "c"))
+        assert result == ["a", "b", "c"]
+
+    def test_empty_dict(self):
+        assert serialize({}) == {}
+
+    def test_empty_list(self):
+        assert serialize([]) == []
+
+
+# ---------------------------------------------------------------------------
+# SDK objects
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeSDKObjects:
+    def test_application_with_enums(self):
+        app = MockApplication()
+        result = serialize(app)
+        assert isinstance(result, dict)
+        assert result["id"] == "0oa1abc123"
+        assert result["status"] == "ACTIVE"
+        assert result["sign_on_mode"] == "SAML_2_0"
+        # Private attributes should be excluded
+        assert "_links" not in result
+        assert "_private_internal" not in result
+
+    def test_user_with_nested_profile(self):
+        user = MockUser()
+        result = serialize(user)
+        assert isinstance(result, dict)
+        assert result["id"] == "00u1xyz789"
+        assert result["status"] == "ACTIVE"
+        assert isinstance(result["profile"], dict)
+        assert result["profile"]["email"] == "user@example.com"
+        assert result["profile"]["firstName"] == "John"
+
+    def test_as_dict_preferred(self):
+        app = MockApplicationWithAsDict()
+        result = serialize(app)
+        assert isinstance(result, dict)
+        assert result["id"] == "0oa1abc123"
+        assert result["name"] == "App via as_dict"
+
+    def test_api_response_object_fallback(self):
+        resp = MockOktaAPIResponse()
+        result = serialize(resp)
+        # All attrs are private, so __dict__ produces empty dict,
+        # fallback to str
+        assert isinstance(result, str)
+
+    def test_list_of_sdk_objects(self):
+        users = [MockUser(), MockUser()]
+        result = serialize(users)
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(u, dict) for u in result)
+        assert result[0]["id"] == "00u1xyz789"
+
+
+# ---------------------------------------------------------------------------
+# JSON-safe validation
+# ---------------------------------------------------------------------------
+
+
+class TestJSONSafe:
+    def test_application_is_json_serializable(self):
+        app = MockApplication()
+        result = serialize(app)
+        # Should not raise
+        json_str = json.dumps(result)
+        assert isinstance(json_str, str)
+
+    def test_user_is_json_serializable(self):
+        user = MockUser()
+        result = serialize(user)
+        json_str = json.dumps(result)
+        assert isinstance(json_str, str)
+
+    def test_list_of_users_is_json_serializable(self):
+        users = [MockUser(), MockUser()]
+        result = serialize(users)
+        json_str = json.dumps(result)
+        parsed = json.loads(json_str)
+        assert len(parsed) == 2
+
+    def test_tuple_items_are_json_serializable(self):
+        """Tuples (the old list_users format) should become JSON arrays."""
+        old_format = (
+            MockProfile(email="a@b.com", firstName="A"),
+            "00u123",
+        )
+        result = serialize(old_format)
+        json_str = json.dumps(result)
+        assert isinstance(json_str, str)
+
+    def test_complex_nested_structure(self):
+        data = {
+            "user": MockUser(),
+            "apps": [MockApplication()],
+            "status": MockUserStatus.ACTIVE,
+            "metadata": {"count": 1, "mode": MockSignOnMode.SAML_2_0},
+        }
+        result = serialize(data)
+        json_str = json.dumps(result)
+        parsed = json.loads(json_str)
+        assert parsed["status"] == "ACTIVE"
+        assert parsed["metadata"]["mode"] == "SAML_2_0"


### PR DESCRIPTION
## Summary

Fixes #14

All MCP tool responses now return valid JSON-serializable Python values instead of raw SDK objects, Enum repr strings, or tuples.

**Root cause**: The Okta SDK returns model objects with Enum fields and custom `__repr__` methods. When these objects are returned directly from MCP tools, they serialize as Python repr strings (e.g., `<ApplicationSignOnMode.SAML_2_0: 'SAML_2_0'>`) instead of valid JSON.

**Fix**: Add a `serialize()` utility in `utils/serialization.py` that recursively converts:
- **Enum values** → their string values (`"SAML_2_0"` not `<ApplicationSignOnMode.SAML_2_0>`)
- **SDK model objects** → dicts (via `.as_dict()` or `__dict__`, excluding private `_` attrs)
- **Tuples** → lists (fixes `list_users` returning `(profile, id)` tuples)
- **Nested structures** → recursively serialized

**Changes per tool module**:
- `users.py`: Replace `(profile, id)` tuples with `serialize(user)` dicts; fix `get_user` to properly unpack `(user, resp, err)` tuple
- `applications.py`: `serialize()` all app objects (fixes Enum rendering)
- `groups.py`: `serialize()` all group/app objects
- `policies.py`: Replace manual `.as_dict()` calls with `serialize()` for consistency
- `system_logs.py`: `serialize()` log entry objects

Includes 24 tests covering primitives, enums, collections, SDK object mocks, and JSON-safe validation.

## Test plan

- [x] `pytest tests/test_serialization.py -v` passes (24/24)
- [x] All returned values verified JSON-serializable via `json.dumps()`
- [ ] Manual verification with live Okta org: `list_users`, `get_user`, `list_applications`, `get_application`