### PR TITLE
feat: validate url parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "keyrings.alt>=5.0.0",
     "flatdict>=4.1.0"
     "setuptools>=75.0.0,<81.0.0",
+    "flatdict>=4.1.0"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "keyring>=25.6.0",
     "keyrings.alt>=5.0.0",
     "flatdict>=4.1.0"
+    "setuptools>=75.0.0,<81.0.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ dependencies = [
     "ruff>=0.11.13",
     "keyring>=25.6.0",
     "keyrings.alt>=5.0.0",
-    "flatdict>=4.1.0"
-    "setuptools>=75.0.0,<81.0.0",
-    "flatdict>=4.1.0"
+    "flatdict>=4.1.0",
 ]
 
 [build-system]

--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
-from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
+from okta_mcp_server.utils.validation import validate_ids
 
 
 @mcp.tool()
@@ -89,6 +89,7 @@ async def list_applications(
 
 
 @mcp.tool()
+@validate_ids("app_id", error_return_type="dict")
 async def get_application(ctx: Context, app_id: str, expand: Optional[str] = None) -> Any:
     """Get an application by ID from the Okta organization.
 
@@ -101,12 +102,6 @@ async def get_application(ctx: Context, app_id: str, expand: Optional[str] = Non
         Dictionary containing the application details or error information.
     """
     logger.info(f"Getting application with ID: {app_id}")
-
-    try:
-        validate_okta_id(app_id, "app_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid app_id: {e}")
-        return {"error": str(e)}
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -166,6 +161,7 @@ async def create_application(ctx: Context, app_config: Dict[str, Any], activate:
 
 
 @mcp.tool()
+@validate_ids("app_id", error_return_type="dict")
 async def update_application(ctx: Context, app_id: str, app_config: Dict[str, Any]) -> Any:
     """Update an application by ID in the Okta organization.
 
@@ -177,12 +173,6 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
         Dictionary containing the updated application details or error information.
     """
     logger.info(f"Updating application with ID: {app_id}")
-
-    try:
-        validate_okta_id(app_id, "app_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid app_id: {e}")
-        return {"error": str(e)}
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -204,6 +194,7 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
 
 
 @mcp.tool()
+@validate_ids("app_id")
 async def delete_application(ctx: Context, app_id: str) -> list:
     """Delete an application by ID from the Okta organization.
 
@@ -230,6 +221,7 @@ async def delete_application(ctx: Context, app_id: str) -> list:
 
 
 @mcp.tool()
+@validate_ids("app_id")
 async def confirm_delete_application(ctx: Context, app_id: str, confirmation: str) -> list:
     """Confirm and execute application deletion after receiving confirmation.
 
@@ -244,12 +236,6 @@ async def confirm_delete_application(ctx: Context, app_id: str, confirmation: st
         List containing the result of the deletion operation.
     """
     logger.info(f"Processing deletion confirmation for application {app_id}")
-
-    try:
-        validate_okta_id(app_id, "app_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid app_id: {e}")
-        return [f"Error: {e}"]
 
     if confirmation != "DELETE":
         logger.warning(f"Application deletion cancelled for {app_id} - incorrect confirmation")
@@ -275,6 +261,7 @@ async def confirm_delete_application(ctx: Context, app_id: str, confirmation: st
 
 
 @mcp.tool()
+@validate_ids("app_id")
 async def activate_application(ctx: Context, app_id: str) -> list:
     """Activate an application in the Okta organization.
 
@@ -285,12 +272,6 @@ async def activate_application(ctx: Context, app_id: str) -> list:
         List containing the result of the activation operation.
     """
     logger.info(f"Activating application: {app_id}")
-
-    try:
-        validate_okta_id(app_id, "app_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid app_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -312,6 +293,7 @@ async def activate_application(ctx: Context, app_id: str) -> list:
 
 
 @mcp.tool()
+@validate_ids("app_id")
 async def deactivate_application(ctx: Context, app_id: str) -> list:
     """Deactivate an application in the Okta organization.
 
@@ -322,12 +304,6 @@ async def deactivate_application(ctx: Context, app_id: str) -> list:
         List containing the result of the deactivation operation.
     """
     logger.info(f"Deactivating application: {app_id}")
-
-    try:
-        validate_okta_id(app_id, "app_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid app_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 

--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
+from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
 
 
 @mcp.tool()
@@ -101,6 +102,12 @@ async def get_application(ctx: Context, app_id: str, expand: Optional[str] = Non
     """
     logger.info(f"Getting application with ID: {app_id}")
 
+    try:
+        validate_okta_id(app_id, "app_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid app_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -171,6 +178,12 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
     """
     logger.info(f"Updating application with ID: {app_id}")
 
+    try:
+        validate_okta_id(app_id, "app_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid app_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -232,6 +245,12 @@ async def confirm_delete_application(ctx: Context, app_id: str, confirmation: st
     """
     logger.info(f"Processing deletion confirmation for application {app_id}")
 
+    try:
+        validate_okta_id(app_id, "app_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid app_id: {e}")
+        return [f"Error: {e}"]
+
     if confirmation != "DELETE":
         logger.warning(f"Application deletion cancelled for {app_id} - incorrect confirmation")
         return ["Error: Deletion cancelled. Confirmation 'DELETE' was not provided correctly."]
@@ -267,6 +286,12 @@ async def activate_application(ctx: Context, app_id: str) -> list:
     """
     logger.info(f"Activating application: {app_id}")
 
+    try:
+        validate_okta_id(app_id, "app_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid app_id: {e}")
+        return [f"Error: {e}"]
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -297,6 +322,12 @@ async def deactivate_application(ctx: Context, app_id: str) -> list:
         List containing the result of the deactivation operation.
     """
     logger.info(f"Deactivating application: {app_id}")
+
+    try:
+        validate_okta_id(app_id, "app_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid app_id: {e}")
+        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -261,7 +261,7 @@ async def confirm_delete_group(group_id: str, confirmation: str, ctx: Context = 
 
     if confirmation != "DELETE":
         logger.warning(f"Group deletion cancelled for {group_id} - incorrect confirmation")
-        return [f"Error: Deletion cancelled. Confirmation 'DELETE' was not provided correctly."]
+        return [{"error": "Deletion cancelled. Confirmation 'DELETE' was not provided correctly."}]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -273,13 +273,13 @@ async def confirm_delete_group(group_id: str, confirmation: str, ctx: Context = 
 
         if err:
             logger.error(f"Okta API error while deleting group {group_id}: {err}")
-            return [f"Error: {err}"]
+            return [{"error": str(err)}]
 
         logger.info(f"Successfully deleted group: {group_id}")
-        return [f"Group {group_id} deleted successfully"]
+        return [{"message": f"Group {group_id} deleted successfully"}]
     except Exception as e:
         logger.error(f"Exception while deleting group {group_id}: {type(e).__name__}: {e}")
-        return [f"Exception: {e}"]
+        return [{"error": str(e)}]
 
 
 @mcp.tool()

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
 
 
 @mcp.tool()
@@ -116,6 +117,12 @@ async def get_group(group_id: str, ctx: Context = None) -> list:
     """
     logger.info(f"Getting group with ID: {group_id}")
 
+    try:
+        validate_okta_id(group_id, "group_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid group_id: {e}")
+        return {"error": f"Error: {e}"}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -218,6 +225,12 @@ async def confirm_delete_group(group_id: str, confirmation: str, ctx: Context = 
     """
     logger.info(f"Processing deletion confirmation for group {group_id}")
 
+    try:
+        validate_okta_id(group_id, "group_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid group_id: {e}")
+        return [{"error": f"Error: {e}"}]
+
     # Step 3: Check confirmation and delete if correct
     if confirmation != "DELETE":
         logger.warning(f"Group deletion cancelled for {group_id} - incorrect confirmation")
@@ -257,6 +270,12 @@ async def update_group(group_id: str, profile: dict, ctx: Context = None) -> lis
     """
     logger.info(f"Updating group with ID: {group_id}")
     logger.debug(f"Updated fields: {list(profile.keys())}")
+
+    try:
+        validate_okta_id(group_id, "group_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid group_id: {e}")
+        return {"error": f"Error: {e}"}
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -313,6 +332,12 @@ async def list_group_users(
     """
     logger.info(f"Listing users in group: {group_id}")
     logger.debug(f"fetch_all: {fetch_all}, after: '{after}', limit: {limit}")
+
+    try:
+        validate_okta_id(group_id, "group_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid group_id: {e}")
+        return {"error": f"Error: {e}"}
 
     # Validate limit parameter range
     if limit is not None:
@@ -372,6 +397,12 @@ async def list_group_apps(group_id: str, ctx: Context = None) -> list:
     """
     logger.info(f"Listing applications assigned to group: {group_id}")
 
+    try:
+        validate_okta_id(group_id, "group_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid group_id: {e}")
+        return {"error": f"Error: {e}"}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -408,6 +439,13 @@ async def add_user_to_group(group_id: str, user_id: str, ctx: Context = None) ->
     """
     logger.info(f"Adding user {user_id} to group {group_id}")
 
+    try:
+        validate_okta_id(group_id, "group_id")
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": f"Error: {e}"}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -441,6 +479,13 @@ async def remove_user_from_group(group_id: str, user_id: str, ctx: Context = Non
         List containing the result of the removal operation.
     """
     logger.info(f"Removing user {user_id} from group {group_id}")
+
+    try:
+        validate_okta_id(group_id, "group_id")
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": f"Error: {e}"}
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
+from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
 
 
 @mcp.tool()
@@ -94,6 +95,12 @@ async def get_policy(ctx: Context, policy_id: str) -> Optional[Dict[str, Any]]:
     Returns:
         Dict containing the policy details.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -157,6 +164,12 @@ async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any
     Returns:
         Dict containing the updated policy details.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -184,6 +197,12 @@ async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -211,6 +230,12 @@ async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -238,6 +263,12 @@ async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -269,6 +300,12 @@ async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
             - next_page_token (Optional[str]): Token for next page
             - error (str): Error message if the operation fails
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -305,6 +342,13 @@ async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optiona
     Returns:
         Dict containing the policy rule details.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+        validate_okta_id(rule_id, "rule_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -338,6 +382,12 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
     Returns:
         Dict containing the created rule details.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid policy_id: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -369,6 +419,13 @@ async def update_policy_rule(
     Returns:
         Dict containing the updated rule details.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+        validate_okta_id(rule_id, "rule_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -397,6 +454,13 @@ async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+        validate_okta_id(rule_id, "rule_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -425,6 +489,13 @@ async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Di
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+        validate_okta_id(rule_id, "rule_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -453,6 +524,13 @@ async def deactivate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> 
     Returns:
         Dict with success status.
     """
+    try:
+        validate_okta_id(policy_id, "policy_id")
+        validate_okta_id(rule_id, "rule_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid ID: {e}")
+        return {"error": str(e)}
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
-from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
+from okta_mcp_server.utils.validation import validate_ids
 
 
 @mcp.tool()
@@ -86,6 +86,7 @@ async def list_policies(
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def get_policy(ctx: Context, policy_id: str) -> Optional[Dict[str, Any]]:
     """Retrieve a specific policy by ID.
 
@@ -95,12 +96,6 @@ async def get_policy(ctx: Context, policy_id: str) -> Optional[Dict[str, Any]]:
     Returns:
         Dict containing the policy details.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -154,6 +149,7 @@ async def create_policy(ctx: Context, policy_data: Dict[str, Any]) -> Optional[D
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update an existing policy.
 
@@ -164,12 +160,6 @@ async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any
     Returns:
         Dict containing the updated policy details.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -188,6 +178,7 @@ async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     """Delete a policy.
 
@@ -197,12 +188,6 @@ async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -221,6 +206,7 @@ async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     """Activate a policy.
 
@@ -230,12 +216,6 @@ async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -254,6 +234,7 @@ async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     """Deactivate a policy.
 
@@ -263,12 +244,6 @@ async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -287,6 +262,7 @@ async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
     """List all rules for a specific policy.
 
@@ -300,12 +276,6 @@ async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
             - next_page_token (Optional[str]): Token for next page
             - error (str): Error message if the operation fails
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -332,6 +302,7 @@ async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
 
 @mcp.tool()
+@validate_ids("policy_id", "rule_id", error_return_type="dict")
 async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optional[Dict[str, Any]]:
     """Retrieve a specific policy rule.
 
@@ -342,13 +313,6 @@ async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optiona
     Returns:
         Dict containing the policy rule details.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-        validate_okta_id(rule_id, "rule_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid ID: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -367,6 +331,7 @@ async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optiona
 
 
 @mcp.tool()
+@validate_ids("policy_id", error_return_type="dict")
 async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Create a new rule for a policy.
 
@@ -382,12 +347,6 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
     Returns:
         Dict containing the created rule details.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid policy_id: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -406,6 +365,7 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
 
 
 @mcp.tool()
+@validate_ids("policy_id", "rule_id", error_return_type="dict")
 async def update_policy_rule(
     ctx: Context, policy_id: str, rule_id: str, rule_data: Dict[str, Any]
 ) -> Optional[Dict[str, Any]]:
@@ -419,13 +379,6 @@ async def update_policy_rule(
     Returns:
         Dict containing the updated rule details.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-        validate_okta_id(rule_id, "rule_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid ID: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -444,6 +397,7 @@ async def update_policy_rule(
 
 
 @mcp.tool()
+@validate_ids("policy_id", "rule_id", error_return_type="dict")
 async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict[str, Any]:
     """Delete a policy rule.
 
@@ -454,13 +408,6 @@ async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-        validate_okta_id(rule_id, "rule_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid ID: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -479,6 +426,7 @@ async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict
 
 
 @mcp.tool()
+@validate_ids("policy_id", "rule_id", error_return_type="dict")
 async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict[str, Any]:
     """Activate a policy rule.
 
@@ -489,13 +437,6 @@ async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Di
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-        validate_okta_id(rule_id, "rule_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid ID: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 
@@ -514,6 +455,7 @@ async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Di
 
 
 @mcp.tool()
+@validate_ids("policy_id", "rule_id", error_return_type="dict")
 async def deactivate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict[str, Any]:
     """Deactivate a policy rule.
 
@@ -524,13 +466,6 @@ async def deactivate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> 
     Returns:
         Dict with success status.
     """
-    try:
-        validate_okta_id(policy_id, "policy_id")
-        validate_okta_id(rule_id, "rule_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid ID: {e}")
-        return {"error": str(e)}
-
     manager = ctx.request_context.lifespan_context.okta_auth_manager
     okta_client = await get_okta_client(manager)
 

--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
 
 
 @mcp.tool()
@@ -164,6 +165,12 @@ async def get_user(user_id: str, ctx: Context = None) -> list:
     """
     logger.info(f"Getting user with ID: {user_id}")
 
+    try:
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid user_id: {e}")
+        return [f"Error: {e}"]
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -232,6 +239,12 @@ async def update_user(user_id: str, profile: dict, ctx: Context = None) -> list:
     """
     logger.info(f"Updating user with ID: {user_id}")
 
+    try:
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid user_id: {e}")
+        return [f"Error: {e}"]
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -267,6 +280,12 @@ async def deactivate_user(user_id: str, ctx: Context = None) -> list:
     """
     logger.info(f"Deactivating user with ID: {user_id}")
 
+    try:
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid user_id: {e}")
+        return [f"Error: {e}"]
+
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
@@ -299,6 +318,12 @@ async def delete_deactivated_user(user_id: str, ctx: Context = None) -> list:
         List containing the result of the deletion operation.
     """
     logger.info(f"Deleting deactivated user with ID: {user_id}")
+
+    try:
+        validate_okta_id(user_id, "user_id")
+    except InvalidOktaIdError as e:
+        logger.error(f"Invalid user_id: {e}")
+        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 

--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -13,7 +13,7 @@ from mcp.server.fastmcp import Context
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
-from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
+from okta_mcp_server.utils.validation import validate_ids
 
 
 @mcp.tool()
@@ -152,6 +152,7 @@ async def get_user_profile_attributes(ctx: Context = None) -> list:
 
 
 @mcp.tool()
+@validate_ids("user_id")
 async def get_user(user_id: str, ctx: Context = None) -> list:
     """Get a user by ID from the Okta organization
 
@@ -164,12 +165,6 @@ async def get_user(user_id: str, ctx: Context = None) -> list:
         List containing the user details.
     """
     logger.info(f"Getting user with ID: {user_id}")
-
-    try:
-        validate_okta_id(user_id, "user_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid user_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -225,6 +220,7 @@ async def create_user(profile: dict, ctx: Context = None) -> list:
 
 
 @mcp.tool()
+@validate_ids("user_id")
 async def update_user(user_id: str, profile: dict, ctx: Context = None) -> list:
     """Update a user in the Okta organization.
 
@@ -238,12 +234,6 @@ async def update_user(user_id: str, profile: dict, ctx: Context = None) -> list:
         List containing the updated user details.
     """
     logger.info(f"Updating user with ID: {user_id}")
-
-    try:
-        validate_okta_id(user_id, "user_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid user_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -266,6 +256,7 @@ async def update_user(user_id: str, profile: dict, ctx: Context = None) -> list:
 
 
 @mcp.tool()
+@validate_ids("user_id")
 async def deactivate_user(user_id: str, ctx: Context = None) -> list:
     """Deactivates a user from the Okta organization.
 
@@ -279,12 +270,6 @@ async def deactivate_user(user_id: str, ctx: Context = None) -> list:
         List containing the result of the deactivation operation.
     """
     logger.info(f"Deactivating user with ID: {user_id}")
-
-    try:
-        validate_okta_id(user_id, "user_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid user_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
@@ -306,6 +291,7 @@ async def deactivate_user(user_id: str, ctx: Context = None) -> list:
 
 
 @mcp.tool()
+@validate_ids("user_id")
 async def delete_deactivated_user(user_id: str, ctx: Context = None) -> list:
     """Delete a user from the Okta organization who has already been deactivated or deprovisioned.
 
@@ -318,12 +304,6 @@ async def delete_deactivated_user(user_id: str, ctx: Context = None) -> list:
         List containing the result of the deletion operation.
     """
     logger.info(f"Deleting deactivated user with ID: {user_id}")
-
-    try:
-        validate_okta_id(user_id, "user_id")
-    except InvalidOktaIdError as e:
-        logger.error(f"Invalid user_id: {e}")
-        return [f"Error: {e}"]
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 

--- a/src/okta_mcp_server/utils/validation.py
+++ b/src/okta_mcp_server/utils/validation.py
@@ -1,0 +1,91 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""
+Input validation utilities for Okta MCP Server.
+
+This module provides validation functions to prevent path traversal and SSRF attacks
+by ensuring user-supplied IDs do not contain malicious characters that could manipulate
+URL paths when passed to the Okta SDK client.
+"""
+
+import re
+
+from loguru import logger
+
+
+class InvalidOktaIdError(ValueError):
+    """Exception raised when an Okta ID contains invalid characters."""
+
+    pass
+
+
+# Characters that are not allowed in Okta IDs to prevent path traversal
+# This includes path separators, URL-reserved characters, and traversal sequences
+FORBIDDEN_PATTERNS = [
+    "/",  # Path separator
+    "\\",  # Windows path separator
+    "..",  # Path traversal
+    "?",  # Query string delimiter
+    "#",  # Fragment delimiter
+    "%2f",  # URL-encoded forward slash
+    "%2F",  # URL-encoded forward slash (uppercase)
+    "%5c",  # URL-encoded backslash
+    "%5C",  # URL-encoded backslash (uppercase)
+    "%2e%2e",  # URL-encoded ..
+    "%2E%2E",  # URL-encoded .. (uppercase)
+]
+
+# Regex pattern for valid Okta IDs
+# Okta IDs are typically alphanumeric strings, sometimes with hyphens or underscores
+# They may also be email addresses (for user lookups)
+VALID_OKTA_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-@.+]+$")
+
+
+def validate_okta_id(id_value: str, id_type: str = "ID") -> str:
+    """
+    Validate that an Okta ID does not contain path traversal or injection characters.
+
+    This function prevents SSRF attacks where malicious IDs like '../groups/00g123'
+    could be used to target unintended Okta APIs.
+
+    Args:
+        id_value: The ID value to validate (user_id, group_id, policy_id, rule_id, etc.)
+        id_type: A descriptive name for the ID type (used in error messages)
+
+    Returns:
+        The validated ID value (unchanged if valid)
+
+    Raises:
+        InvalidOktaIdError: If the ID contains forbidden characters or patterns
+    """
+    if not id_value:
+        raise InvalidOktaIdError(f"{id_type} cannot be empty")
+
+    if not isinstance(id_value, str):
+        raise InvalidOktaIdError(f"{id_type} must be a string")
+
+    # Check for forbidden patterns (case-insensitive for URL-encoded variants)
+    id_lower = id_value.lower()
+    for pattern in FORBIDDEN_PATTERNS:
+        if pattern.lower() in id_lower:
+            logger.warning(f"Rejected {id_type} containing forbidden pattern '{pattern}': {id_value}")
+            raise InvalidOktaIdError(
+                f"Invalid {id_type}: contains forbidden character or pattern '{pattern}'. "
+                f"IDs must not contain path traversal sequences or URL-reserved characters."
+            )
+
+    # Validate against allowed character pattern
+    if not VALID_OKTA_ID_PATTERN.match(id_value):
+        logger.warning(f"Rejected {id_type} with invalid characters: {id_value}")
+        raise InvalidOktaIdError(
+            f"Invalid {id_type}: contains invalid characters. "
+            f"IDs must contain only alphanumeric characters, hyphens, underscores, "
+            f"at signs, dots, and plus signs."
+        )
+
+    return id_value

--- a/src/okta_mcp_server/utils/validation.py
+++ b/src/okta_mcp_server/utils/validation.py
@@ -1,5 +1,5 @@
 # The Okta software accompanied by this notice is provided pursuant to the following terms:
-# Copyright © 2025-Present, Okta, Inc.
+# Copyright © 2026-Present, Okta, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,7 +13,10 @@ by ensuring user-supplied IDs do not contain malicious characters that could man
 URL paths when passed to the Okta SDK client.
 """
 
+import functools
+import inspect
 import re
+from typing import Any, Callable
 
 from loguru import logger
 
@@ -43,7 +46,22 @@ FORBIDDEN_PATTERNS = [
 # Regex pattern for valid Okta IDs
 # Okta IDs are typically alphanumeric strings, sometimes with hyphens or underscores
 # They may also be email addresses (for user lookups)
+#
+# IMPORTANT: The forbidden patterns check MUST run BEFORE the regex validation.
+# The regex allows dots (for email addresses like user@example.com), but ".."
+# is caught by the forbidden patterns list. This ordering ensures path traversal
+# sequences like ".." are rejected even though single dots are allowed.
 VALID_OKTA_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_\-@.+]+$")
+
+# Maximum length of ID to log (to prevent log injection attacks)
+MAX_LOG_ID_LENGTH = 100
+
+
+def _sanitize_for_log(value: str) -> str:
+    """Sanitize a value for safe logging by truncating and escaping."""
+    if len(value) > MAX_LOG_ID_LENGTH:
+        return f"{value[:MAX_LOG_ID_LENGTH]}... (truncated)"
+    return value
 
 
 def validate_okta_id(id_value: str, id_type: str = "ID") -> str:
@@ -69,11 +87,15 @@ def validate_okta_id(id_value: str, id_type: str = "ID") -> str:
     if not isinstance(id_value, str):
         raise InvalidOktaIdError(f"{id_type} must be a string")
 
-    # Check for forbidden patterns (case-insensitive for URL-encoded variants)
+    # IMPORTANT: Check forbidden patterns FIRST before regex validation.
+    # The regex allows dots (for emails), but we must reject ".." sequences.
     id_lower = id_value.lower()
     for pattern in FORBIDDEN_PATTERNS:
         if pattern.lower() in id_lower:
-            logger.warning(f"Rejected {id_type} containing forbidden pattern '{pattern}': {id_value}")
+            logger.warning(
+                f"Rejected {id_type} containing forbidden pattern '{pattern}': "
+                f"{_sanitize_for_log(id_value)}"
+            )
             raise InvalidOktaIdError(
                 f"Invalid {id_type}: contains forbidden character or pattern '{pattern}'. "
                 f"IDs must not contain path traversal sequences or URL-reserved characters."
@@ -81,7 +103,7 @@ def validate_okta_id(id_value: str, id_type: str = "ID") -> str:
 
     # Validate against allowed character pattern
     if not VALID_OKTA_ID_PATTERN.match(id_value):
-        logger.warning(f"Rejected {id_type} with invalid characters: {id_value}")
+        logger.warning(f"Rejected {id_type} with invalid characters: {_sanitize_for_log(id_value)}")
         raise InvalidOktaIdError(
             f"Invalid {id_type}: contains invalid characters. "
             f"IDs must contain only alphanumeric characters, hyphens, underscores, "
@@ -89,3 +111,84 @@ def validate_okta_id(id_value: str, id_type: str = "ID") -> str:
         )
 
     return id_value
+
+
+def validate_ids(*id_params: str, error_return_type: str = "list"):
+    """
+    Decorator that validates specified ID parameters before function execution.
+
+    This decorator extracts the named parameters from the function call and validates
+    each one using validate_okta_id(). If any validation fails, it returns an error
+    response in the specified format without executing the wrapped function.
+
+    Args:
+        *id_params: Names of function parameters to validate (e.g., "user_id", "group_id")
+        error_return_type: Format of error response - "list" or "dict"
+
+    Usage:
+        @validate_ids("user_id")
+        async def get_user(user_id: str, ctx: Context = None) -> list:
+            ...
+
+        @validate_ids("group_id", "user_id")
+        async def add_user_to_group(group_id: str, user_id: str, ctx: Context = None) -> list:
+            ...
+
+        @validate_ids("policy_id", error_return_type="dict")
+        async def get_policy(ctx: Context, policy_id: str) -> dict:
+            ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs) -> Any:
+            # Get function signature to map positional args to parameter names
+            sig = inspect.signature(func)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            # Validate each specified ID parameter
+            for param_name in id_params:
+                if param_name in bound_args.arguments:
+                    id_value = bound_args.arguments[param_name]
+                    if id_value is not None:  # Skip None values (optional params)
+                        try:
+                            validate_okta_id(id_value, param_name)
+                        except InvalidOktaIdError as e:
+                            logger.error(f"Invalid {param_name}: {e}")
+                            if error_return_type == "dict":
+                                return {"error": str(e)}
+                            else:  # default to list
+                                return [f"Error: {e}"]
+
+            return await func(*args, **kwargs)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs) -> Any:
+            # Get function signature to map positional args to parameter names
+            sig = inspect.signature(func)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+
+            # Validate each specified ID parameter
+            for param_name in id_params:
+                if param_name in bound_args.arguments:
+                    id_value = bound_args.arguments[param_name]
+                    if id_value is not None:
+                        try:
+                            validate_okta_id(id_value, param_name)
+                        except InvalidOktaIdError as e:
+                            logger.error(f"Invalid {param_name}: {e}")
+                            if error_return_type == "dict":
+                                return {"error": str(e)}
+                            else:
+                                return [f"Error: {e}"]
+
+            return func(*args, **kwargs)
+
+        # Return appropriate wrapper based on whether function is async
+        if inspect.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorator

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,5 @@
 # The Okta software accompanied by this notice is provided pursuant to the following terms:
-# Copyright © 2025-Present, Okta, Inc.
+# Copyright © 2026-Present, Okta, Inc.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,161 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2025-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""
+Unit tests for the validation module.
+
+These tests verify that the validate_okta_id function properly blocks
+path traversal and injection attacks while allowing valid Okta IDs.
+"""
+
+import pytest
+
+from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
+
+
+class TestValidateOktaId:
+    """Tests for the validate_okta_id function."""
+
+    def test_valid_okta_user_id(self):
+        """Test that valid Okta user IDs are accepted."""
+        valid_ids = [
+            "00u1234567890ABCDEF",
+            "00uabcdefghijklmnop",
+            "00u123ABC456DEF789",
+        ]
+        for id_value in valid_ids:
+            result = validate_okta_id(id_value, "user_id")
+            assert result == id_value
+
+    def test_valid_okta_group_id(self):
+        """Test that valid Okta group IDs are accepted."""
+        valid_ids = [
+            "00g1234567890ABCDEF",
+            "00gabcdefghijklmnop",
+        ]
+        for id_value in valid_ids:
+            result = validate_okta_id(id_value, "group_id")
+            assert result == id_value
+
+    def test_valid_email_as_user_id(self):
+        """Test that email addresses are accepted as user IDs (Okta supports this)."""
+        valid_emails = [
+            "user@example.com",
+            "john.doe@company.org",
+            "user+tag@example.com",
+        ]
+        for email in valid_emails:
+            result = validate_okta_id(email, "user_id")
+            assert result == email
+
+    def test_path_traversal_with_forward_slash(self):
+        """Test that path traversal using forward slashes is blocked."""
+        malicious_ids = [
+            "../groups/00g123",
+            "00u123/../../groups/00g456",
+            "/api/v1/groups",
+            "00u123/../00g456",
+        ]
+        for malicious_id in malicious_ids:
+            with pytest.raises(InvalidOktaIdError) as exc_info:
+                validate_okta_id(malicious_id, "user_id")
+            assert "forbidden" in str(exc_info.value).lower()
+
+    def test_path_traversal_with_backslash(self):
+        """Test that path traversal using backslashes is blocked."""
+        malicious_ids = [
+            "..\\groups\\00g123",
+            "00u123\\..\\..\\groups",
+        ]
+        for malicious_id in malicious_ids:
+            with pytest.raises(InvalidOktaIdError) as exc_info:
+                validate_okta_id(malicious_id, "user_id")
+            assert "forbidden" in str(exc_info.value).lower()
+
+    def test_path_traversal_with_dot_dot(self):
+        """Test that .. sequences are blocked even without slashes."""
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id("00u123..00g456", "user_id")
+        assert "forbidden" in str(exc_info.value).lower()
+
+    def test_url_encoded_path_traversal(self):
+        """Test that URL-encoded path traversal attempts are blocked."""
+        malicious_ids = [
+            "%2f..%2fgroups%2f00g123",  # URL-encoded forward slashes
+            "%2F..%2Fgroups%2F00g123",  # URL-encoded forward slashes (uppercase)
+            "%5c..%5cgroups",  # URL-encoded backslashes
+            "%2e%2e%2fgroups",  # URL-encoded ..
+        ]
+        for malicious_id in malicious_ids:
+            with pytest.raises(InvalidOktaIdError) as exc_info:
+                validate_okta_id(malicious_id, "user_id")
+            assert "forbidden" in str(exc_info.value).lower()
+
+    def test_query_string_injection(self):
+        """Test that query string injection attempts are blocked."""
+        malicious_ids = [
+            "00u123?admin=true",
+            "00u123?filter=all",
+        ]
+        for malicious_id in malicious_ids:
+            with pytest.raises(InvalidOktaIdError) as exc_info:
+                validate_okta_id(malicious_id, "user_id")
+            assert "forbidden" in str(exc_info.value).lower()
+
+    def test_fragment_injection(self):
+        """Test that fragment injection attempts are blocked."""
+        malicious_ids = [
+            "00u123#section",
+            "00u123#admin",
+        ]
+        for malicious_id in malicious_ids:
+            with pytest.raises(InvalidOktaIdError) as exc_info:
+                validate_okta_id(malicious_id, "user_id")
+            assert "forbidden" in str(exc_info.value).lower()
+
+    def test_empty_id(self):
+        """Test that empty IDs are rejected."""
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id("", "user_id")
+        assert "empty" in str(exc_info.value).lower()
+
+    def test_non_string_id(self):
+        """Test that non-string IDs are rejected."""
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id(12345, "user_id")
+        assert "string" in str(exc_info.value).lower()
+
+    def test_id_with_spaces(self):
+        """Test that IDs with spaces are rejected."""
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id("00u123 00g456", "user_id")
+        assert "invalid" in str(exc_info.value).lower()
+
+    def test_id_type_in_error_message(self):
+        """Test that the ID type appears in error messages."""
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id("../bad", "policy_id")
+        assert "policy_id" in str(exc_info.value)
+
+    def test_valid_ids_with_hyphens_and_underscores(self):
+        """Test that IDs with hyphens and underscores are accepted."""
+        valid_ids = [
+            "00u-123-456",
+            "00u_123_456",
+            "00u-abc_def",
+        ]
+        for id_value in valid_ids:
+            result = validate_okta_id(id_value, "user_id")
+            assert result == id_value
+
+    def test_ssrf_attack_vector(self):
+        """Test the specific SSRF attack vector from the security report."""
+        # This is the exact attack vector from the security ticket
+        malicious_id = "../groups/00gegmsyuRJro9LWi0w6"
+        with pytest.raises(InvalidOktaIdError) as exc_info:
+            validate_okta_id(malicious_id, "user_id")
+        assert "forbidden" in str(exc_info.value).lower()

--- a/uv.lock
+++ b/uv.lock
@@ -576,7 +576,6 @@ dependencies = [
     { name = "okta" },
     { name = "requests" },
     { name = "ruff" },
-    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -584,12 +583,11 @@ requires-dist = [
     { name = "flatdict", specifier = ">=4.1.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "keyrings-alt", specifier = ">=5.0.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
     { name = "okta", specifier = ">=2.9.13" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=75.0.0,<81.0.0" },
 ]
 
 [[package]]
@@ -964,15 +962,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
-]
-
-[[package]]
-name = "setuptools"
-version = "80.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -576,6 +576,7 @@ dependencies = [
     { name = "okta" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -583,11 +584,12 @@ requires-dist = [
     { name = "flatdict", specifier = ">=4.1.0" },
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "keyrings-alt", specifier = ">=5.0.0" },
-    { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "okta", specifier = ">=2.9.13" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", specifier = ">=0.11.13" },
+    { name = "setuptools", specifier = ">=75.0.0,<81.0.0" },
 ]
 
 [[package]]
@@ -962,6 +964,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739, upload-time = "2022-08-13T16:22:46.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221, upload-time = "2022-08-13T16:22:44.457Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ### Problem

  The Okta SDK client directly appends user-supplied IDs to URL paths without validation. Attackers could exploit this by passing malicious IDs like ../groups/00g123 to target unintended Okta APIs (e.g., accessing Groups API
  through the Users endpoint).

 ### Solution

   - Add validate_okta_id() function that blocks path traversal sequences (/, \, ..), URL-reserved characters (?, #), and their URL-encoded variants
   - Apply validation to all user-supplied path parameters across users, groups, applications, and policies tools
   - Custom InvalidOktaIdError exception for clear error handling