### PR TITLE
feat: Allow overriding SERVICE_NAME from ENV for Multiple Server Parallel Run

### DIFF
--- a/src/okta_mcp_server/utils/auth/auth_manager.py
+++ b/src/okta_mcp_server/utils/auth/auth_manager.py
@@ -20,7 +20,7 @@ import keyring.backend
 import requests
 from loguru import logger
 
-SERVICE_NAME = "OktaAuthManager"
+SERVICE_NAME = os.environ.get("OKTA_SERVICE_NAME", "OktaAuthManager")
 
 
 @dataclass


### PR DESCRIPTION
This allows overriding the Service Name from the ENV to enable running multiple server instances at the same time (manipulating multiple Okta Tenant at the same time)