### PR TITLE
feat: support file path for OKTA_PRIVATE_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,8 @@ OKTA_SCOPES=okta.users.read okta.groups.read
 
 # Optional: For Private Key JWT authentication (browserless)
 # Uncomment and set these if using Private Key JWT instead of Device Authorization
+# OKTA_PRIVATE_KEY can be either the PEM content directly or a path to a PEM file
+# OKTA_PRIVATE_KEY=/path/to/private_key.pem
 # OKTA_PRIVATE_KEY=
 # OKTA_KEY_ID=
 

--- a/src/okta_mcp_server/utils/auth/auth_manager.py
+++ b/src/okta_mcp_server/utils/auth/auth_manager.py
@@ -45,15 +45,22 @@ class OktaAuthManager:
         self.scopes = f"{self.scopes} {os.environ.get('OKTA_SCOPES', '').strip()}"
 
         # Check for browserless auth configuration
-        self.private_key = os.environ.get("OKTA_PRIVATE_KEY")
+        private_key_value = os.environ.get("OKTA_PRIVATE_KEY")
         self.key_id = os.environ.get("OKTA_KEY_ID")
+
+        if private_key_value and os.path.isfile(private_key_value):
+            logger.info(f"Loading private key from file: {private_key_value}")
+            with open(private_key_value) as f:
+                self.private_key = f.read()
+        else:
+            self.private_key = private_key_value
+            # Process private key if it contains escaped newlines
+            if self.private_key and "\\n" in self.private_key:
+                self.private_key = self.private_key.replace("\\n", "\n")
 
         if self.private_key and self.key_id:
             self.use_browserless_auth = True
             logger.info("Browserless authentication is available and will be used")
-            # Process private key if it contains escaped newlines
-            if "\\n" in self.private_key:
-                self.private_key = self.private_key.replace("\\n", "\n")
         else:
             if self.private_key and not self.key_id:
                 logger.warning("Private key found but OKTA_KEY_ID is missing. Using device flow instead.")


### PR DESCRIPTION
## Summary

Allow `OKTA_PRIVATE_KEY` to accept either inline PEM content or a path to a PEM file on disk.

## Changes

- **`auth_manager.py`**: In `__init__`, check if `OKTA_PRIVATE_KEY` is a valid file path using `os.path.isfile()`. If so, read the PEM content from disk. Otherwise, fall back to treating the value as inline PEM (with escaped `\n` handling preserved).
- **`.env.example`**: Added documentation noting that `OKTA_PRIVATE_KEY` accepts either a file path or inline PEM content.

## Behavior

| `OKTA_PRIVATE_KEY` value | Behavior |
|---|---|
| `/path/to/key.pem` (valid file) | Reads PEM content from disk |
| Inline PEM string with escaped newlines | Replaces `\n` literals with real newlines |
| Inline PEM string with real newlines | Used as-is |