### PR TITLE
feat: add Device Assurance Policy tools and upgrade Okta SDK to v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+
+### Added
+- **Device Assurance Policy tools** — 5 new MCP tools to manage Device Assurance Policies across all platforms (Android, iOS, macOS, Windows, ChromeOS):
+  - `list_device_assurance_policies` — list all policies with per-attribute security status
+  - `get_device_assurance_policy` — retrieve a policy by ID
+  - `create_device_assurance_policy` — create a policy with OS version validation
+  - `replace_device_assurance_policy` — fully replace a policy with before/after diff and security implications
+  - `delete_device_assurance_policy` — delete a policy with elicitation-guarded confirmation
+
+### Changed
+- Upgraded Okta Python SDK dependency to `v3.3.0`
+- Updated all tool files (`applications`, `groups`, `policies`, `users`, `system_logs`) for SDK v3.3.0 conventions
+
+### Fixed
+- `delete_user` rename from `deactivate_or_delete_user` (SDK v3.x breaking change)
+- `OktaSignOnPolicyRule` typed model usage so `SIGN_ON` policy rule actions are no longer silently dropped
+- `GroupProfile` attribute error during group creation logging
+- Stale cache and intermittent list failures in pagination
+
 ## v1.0.0
 
 - Initial release of the self hosted okta-mcp-server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## v1.1.0
-
-### Added
-- **Device Assurance Policy tools** — 5 new MCP tools to manage Device Assurance Policies across all platforms (Android, iOS, macOS, Windows, ChromeOS):
-  - `list_device_assurance_policies` — list all policies with per-attribute security status
-  - `get_device_assurance_policy` — retrieve a policy by ID
-  - `create_device_assurance_policy` — create a policy with OS version validation
-  - `replace_device_assurance_policy` — fully replace a policy with before/after diff and security implications
-  - `delete_device_assurance_policy` — delete a policy with elicitation-guarded confirmation
-
-### Changed
-- Upgraded Okta Python SDK dependency to `v3.3.0`
-- Updated all tool files (`applications`, `groups`, `policies`, `users`, `system_logs`) for SDK v3.3.0 conventions
-
-### Fixed
-- `delete_user` rename from `deactivate_or_delete_user` (SDK v3.x breaking change)
-- `OktaSignOnPolicyRule` typed model usage so `SIGN_ON` policy rule actions are no longer silently dropped
-- `GroupProfile` attribute error during group creation logging
-- Stale cache and intermittent list failures in pagination
-
 ## v1.0.0
 
 - Initial release of the self hosted okta-mcp-server.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This server is an [Model Context Protocol](https://modelcontextprotocol.io/intro
 * **Interactive Confirmation via Elicitation:** Destructive operations (deletes, deactivations) prompt the user for confirmation through the [MCP Elicitation API](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) before proceeding, with automatic fallback for clients that do not yet support the feature.
 * **Integration with Okta Admin Management APIs:** Leverages the official Okta APIs to ensure secure and reliable interaction with your Okta org.
 * **Extensible Architecture:** Designed to be easily extended with new functionalities and support for additional Okta API endpoints.
-* **Comprehensive Tool Support:** Full CRUD operations for users, groups, applications, policies, and more.
+* **Comprehensive Tool Support:** Full CRUD operations for users, groups, applications, policies, device assurance policies, and more.
 
 This MCP server utilizes [Okta's Python SDK](https://github.com/okta/okta-sdk-python) to communicate with the Okta APIs, ensuring a robust and well-supported integration.
 
@@ -500,6 +500,16 @@ The Okta MCP Server provides the following tools for LLMs to interact with your 
 | `activate_policy_rule`      | Activate a policy rule                         | - `Activate the new emergency access rule` <br> - `Enable the contractor restrictions` <br> - `Turn on the location-based access rule`                        |
 | `deactivate_policy_rule`    | Deactivate a policy rule (prompts for confirmation) | - `Deactivate the old emergency rule` <br> - `Temporarily disable location restrictions` <br> - `Turn off the device trust requirements for testing`          |
 
+### Device Assurance Policies
+
+| Tool                                  | Description                                                    | Usage Examples                                                                                                                                                                                   |
+| ------------------------------------- | -------------------------------------------------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `list_device_assurance_policies`      | List all Device Assurance Policies in your Okta organization  | - `Show me all device assurance policies` <br> - `Which platforms have device compliance policies?` <br> - `Find policies that block jailbroken devices`                                          |
+| `get_device_assurance_policy`         | Get details of a specific Device Assurance Policy             | - `Show me the iOS device assurance policy` <br> - `What OS version does our MacOS policy require?` <br> - `Is jailbreak detection enabled in our Android policy?`                               |
+| `create_device_assurance_policy`      | Create a new Device Assurance Policy                          | - `Create a MacOS policy requiring OS 14.2 and disk encryption` <br> - `Set up an iOS policy that blocks jailbroken devices` <br> - `Add a Windows compliance policy requiring BitLocker`        |
+| `replace_device_assurance_policy`     | Fully replace an existing Device Assurance Policy             | - `Update the MacOS policy to require OS 14.5` <br> - `Enable secure hardware requirement for our Windows policy` <br> - `Change the minimum OS version for our iOS policy`                      |
+| `delete_device_assurance_policy`      | Delete a Device Assurance Policy (prompts for confirmation)   | - `Delete the old Windows compliance policy` <br> - `Remove the deprecated Android policy` <br> - `Clean up unused device assurance policies`                                                    |
+
 ### Logs
 
 | Tool        | Description                              | Usage Examples                                                                                                                                             |
@@ -508,7 +518,7 @@ The Okta MCP Server provides the following tools for LLMs to interact with your 
 
 ### Confirmation for Destructive Operations
 
-All destructive operations (deleting groups, applications, policies, policy rules and deactivating/deleting users) use the **[MCP Elicitation API](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)** to prompt the user for explicit confirmation before proceeding.
+All destructive operations (deleting groups, applications, policies, policy rules, device assurance policies, and deactivating/deleting users) use the **[MCP Elicitation API](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)** to prompt the user for explicit confirmation before proceeding.
 
 - **Clients that support elicitation** (e.g., Claude Desktop with MCP SDK ≥ 1.26): The user sees a confirmation dialog directly in the chat UI. They can accept, decline, or cancel.
 - **Clients that do not yet support elicitation**: The tool returns a JSON payload describing the pending action so the LLM can relay the confirmation request to the user. The deprecated `confirm_delete_group` / `confirm_delete_application` tools remain available as a fallback for these clients.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This server is an [Model Context Protocol](https://modelcontextprotocol.io/intro
 * **Extensible Architecture:** Designed to be easily extended with new functionalities and support for additional Okta API endpoints.
 * **Comprehensive Tool Support:** Full CRUD operations for users, groups, applications, policies, device assurance policies, and more.
 
-This MCP server utilizes [Okta's Python SDK](https://github.com/okta/okta-sdk-python) to communicate with the Okta APIs, ensuring a robust and well-supported integration.
+This MCP server utilizes [Okta's Python SDK v3.3.0](https://github.com/okta/okta-sdk-python) to communicate with the Okta APIs, ensuring a robust and well-supported integration.
 
 ## 🚀 Getting Started
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This server is an [Model Context Protocol](https://modelcontextprotocol.io/intro
 * **Extensible Architecture:** Designed to be easily extended with new functionalities and support for additional Okta API endpoints.
 * **Comprehensive Tool Support:** Full CRUD operations for users, groups, applications, policies, device assurance policies, and more.
 
-This MCP server utilizes [Okta's Python SDK v3.3.0](https://github.com/okta/okta-sdk-python) to communicate with the Okta APIs, ensuring a robust and well-supported integration.
+This MCP server utilizes [Okta's Python SDK v3.4.1](https://github.com/okta/okta-sdk-python) to communicate with the Okta APIs, ensuring a robust and well-supported integration.
 
 ## 🚀 Getting Started
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "loguru>=0.7.3",
     "mcp[cli]>=1.26.0,<2.0.0",
-    "okta>=2.9.13",
+    "okta>=3.1.0",
     "requests>=2.32.4",
     "ruff>=0.11.13",
     "keyring>=25.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "loguru>=0.7.3",
     "mcp[cli]>=1.26.0,<2.0.0",
-    "okta>=3.1.0",
+    "okta==3.3.0",
     "requests>=2.32.4",
     "ruff>=0.11.13",
     "keyring>=25.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "loguru>=0.7.3",
     "mcp[cli]>=1.26.0,<2.0.0",
-    "okta==3.3.0",
+    "okta==3.4.1",
     "requests>=2.32.4",
     "ruff>=0.11.13",
     "keyring>=25.6.0",

--- a/src/okta_mcp_server/server.py
+++ b/src/okta_mcp_server/server.py
@@ -65,6 +65,7 @@ def main():
 
     logger.info("Starting Okta MCP Server")
     from okta_mcp_server.tools.applications import applications  # noqa: F401
+    from okta_mcp_server.tools.device_assurance import device_assurance  # noqa: F401
     from okta_mcp_server.tools.groups import groups  # noqa: F401
     from okta_mcp_server.tools.policies import policies  # noqa: F401
     from okta_mcp_server.tools.system_logs import system_logs  # noqa: F401

--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -70,10 +70,10 @@ async def list_applications(
         if expand:
             query_params["expand"] = expand
         if include_non_deleted is not None:
-            query_params["includeNonDeleted"] = include_non_deleted
+            query_params["include_non_deleted"] = include_non_deleted
 
         logger.debug("Calling Okta API to list applications")
-        apps, _, err = await client.list_applications(query_params)
+        apps, _, err = await client.list_applications(**query_params)
 
         if err:
             logger.error(f"Okta API error while listing applications: {err}")
@@ -114,7 +114,7 @@ async def get_application(ctx: Context, app_id: str, expand: Optional[str] = Non
         if expand:
             query_params["expand"] = expand
 
-        app, _, err = await client.get_application(app_id, query_params)
+        app, _, err = await client.get_application(app_id, **query_params)
 
         if err:
             logger.error(f"Okta API error while getting application {app_id}: {err}")
@@ -146,10 +146,8 @@ async def create_application(ctx: Context, app_config: Dict[str, Any], activate:
     try:
         client = await get_okta_client(manager)
 
-        query_params = {"activate": activate}
-
         logger.debug("Calling Okta API to create application")
-        app, _, err = await client.create_application(app_config, query_params)
+        app, _, err = await client.create_application(app_config, activate)
 
         if err:
             logger.error(f"Okta API error while creating application: {err}")
@@ -182,7 +180,7 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
         client = await get_okta_client(manager)
 
         logger.debug(f"Calling Okta API to update application {app_id}")
-        app, _, err = await client.update_application(app_id, app_config)
+        app, _, err = await client.replace_application(app_id, app_config)
 
         if err:
             logger.error(f"Okta API error while updating application {app_id}: {err}")
@@ -243,7 +241,7 @@ async def delete_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete application {app_id}")
 
-        _, err = await client.delete_application(app_id)
+        _, _, err = await client.delete_application(app_id)
 
         if err:
             logger.error(f"Okta API error while deleting application {app_id}: {err}")
@@ -288,7 +286,7 @@ async def confirm_delete_application(ctx: Context, app_id: str, confirmation: st
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete application {app_id}")
 
-        _, err = await client.delete_application(app_id)
+        _, _, err = await client.delete_application(app_id)
 
         if err:
             logger.error(f"Okta API error while deleting application {app_id}: {err}")
@@ -320,7 +318,7 @@ async def activate_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to activate application {app_id}")
 
-        _, err = await client.activate_application(app_id)
+        _, _, err = await client.activate_application(app_id)
 
         if err:
             logger.error(f"Okta API error while activating application {app_id}: {err}")
@@ -363,7 +361,7 @@ async def deactivate_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to deactivate application {app_id}")
 
-        _, err = await client.deactivate_application(app_id)
+        _, _, err = await client.deactivate_application(app_id)
 
         if err:
             logger.error(f"Okta API error while deactivating application {app_id}: {err}")

--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -7,10 +7,39 @@
 
 from typing import Any, Dict, Optional
 
+import okta.models as okta_models
 from loguru import logger
 from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
+
+# Mapping of signOnMode -> Okta SDK model class for proper serialization
+_SIGN_ON_MODE_MODEL_MAP: Dict[str, Any] = {
+    "BOOKMARK": okta_models.BookmarkApplication,
+    "AUTO_LOGIN": okta_models.AutoLoginApplication,
+    "BASIC_AUTH": okta_models.BasicAuthApplication,
+    "BROWSER_PLUGIN": okta_models.BrowserPluginApplication,
+    "OPENID_CONNECT": okta_models.OpenIdConnectApplication,
+    "SAML_1_1": okta_models.Saml11Application,
+    "SAML_2_0": okta_models.SamlApplication,
+    "SECURE_PASSWORD_STORE": okta_models.SecurePasswordStoreApplication,
+    "WS_FEDERATION": okta_models.WsFederationApplication,
+}
+
+
+def _build_application_model(app_config: Dict[str, Any]) -> Any:
+    """Convert a plain dict to the appropriate Okta SDK Application model.
+
+    The SDK v3 requires typed model objects, not plain dicts. Without this,
+    subclass-specific fields like `name`, `settings`, and `visibility` are
+    silently dropped by the base Application model, causing API validation errors.
+    """
+    sign_on_mode = app_config.get("signOnMode") or app_config.get("sign_on_mode", "")
+    model_cls = _SIGN_ON_MODE_MODEL_MAP.get(str(sign_on_mode).upper(), okta_models.Application)
+    logger.debug(f"Using model class '{model_cls.__name__}' for signOnMode '{sign_on_mode}'")
+    return model_cls(**app_config)
+
+
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeactivateConfirmation, DeleteConfirmation, elicit_or_fallback
 from okta_mcp_server.utils.messages import DEACTIVATE_APPLICATION, DELETE_APPLICATION
@@ -146,8 +175,9 @@ async def create_application(ctx: Context, app_config: Dict[str, Any], activate:
     try:
         client = await get_okta_client(manager)
 
+        application_model = _build_application_model(app_config)
         logger.debug("Calling Okta API to create application")
-        app, _, err = await client.create_application(app_config, activate)
+        app, _, err = await client.create_application(application_model, activate)
 
         if err:
             logger.error(f"Okta API error while creating application: {err}")
@@ -179,8 +209,9 @@ async def update_application(ctx: Context, app_id: str, app_config: Dict[str, An
     try:
         client = await get_okta_client(manager)
 
+        application_model = _build_application_model(app_config)
         logger.debug(f"Calling Okta API to update application {app_id}")
-        app, _, err = await client.replace_application(app_id, app_config)
+        app, _, err = await client.replace_application(app_id, application_model)
 
         if err:
             logger.error(f"Okta API error while updating application {app_id}: {err}")
@@ -241,7 +272,8 @@ async def delete_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete application {app_id}")
 
-        _, _, err = await client.delete_application(app_id)
+        result = await client.delete_application(app_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deleting application {app_id}: {err}")
@@ -286,7 +318,8 @@ async def confirm_delete_application(ctx: Context, app_id: str, confirmation: st
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete application {app_id}")
 
-        _, _, err = await client.delete_application(app_id)
+        result = await client.delete_application(app_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deleting application {app_id}: {err}")
@@ -318,7 +351,8 @@ async def activate_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to activate application {app_id}")
 
-        _, _, err = await client.activate_application(app_id)
+        result = await client.activate_application(app_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while activating application {app_id}: {err}")
@@ -361,7 +395,8 @@ async def deactivate_application(ctx: Context, app_id: str) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to deactivate application {app_id}")
 
-        _, _, err = await client.deactivate_application(app_id)
+        result = await client.deactivate_application(app_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deactivating application {app_id}: {err}")

--- a/src/okta_mcp_server/tools/device_assurance/__init__.py
+++ b/src/okta_mcp_server/tools/device_assurance/__init__.py
@@ -1,0 +1,6 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -38,6 +38,15 @@ _PLATFORM_SECURITY_ATTRIBUTES: Dict[str, List[str]] = {
     "CHROMEOS": ["osVersion"],
 }
 
+# Maps each attribute to the ONLY platforms that support it.
+# Any other platform combination must be rejected before hitting the API.
+_PLATFORM_ONLY_ATTRIBUTES: Dict[str, List[str]] = {
+    "diskEncryptionType": ["MACOS", "WINDOWS"],
+    "secureHardwarePresent": ["MACOS", "WINDOWS"],
+    "jailbreak": ["ANDROID", "IOS"],
+    "screenLockType": ["ANDROID", "IOS", "MACOS", "WINDOWS"],
+}
+
 
 def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
     """Validate and normalise osVersion.minimum format if present.
@@ -68,6 +77,33 @@ def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
         logger.debug(f"Normalised OS version '{minimum}' → '{normalized}'")
         os_version["minimum"] = normalized
 
+    return None
+
+
+def _validate_platform_attributes(policy_data: Dict[str, Any]) -> Optional[str]:
+    """Validate that the requested attributes are supported by the given platform.
+
+    Returns an error message string if incompatible attributes are found, None if valid.
+    """
+    platform = (policy_data.get("platform") or "").upper()
+    if not platform:
+        return None
+
+    errors = []
+    for attr, supported_platforms in _PLATFORM_ONLY_ATTRIBUTES.items():
+        if policy_data.get(attr) is not None:
+            if platform not in supported_platforms:
+                errors.append(
+                    f"'{attr}' is not supported for {platform} — "
+                    f"only available on: {', '.join(supported_platforms)}."
+                )
+
+    if errors:
+        return (
+            f"Invalid policy configuration for platform {platform}: "
+            + " ".join(errors)
+            + " Remove the unsupported attribute(s) and try again."
+        )
     return None
 
 
@@ -173,9 +209,21 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
     block jailbroken/rooted devices, or identify policies whose platform
     requirements may be outdated.
 
+    IMPORTANT — always call fresh: Never reuse results from a previous call
+    to resolve a policy name to an ID. Always call this tool again to get
+    an up-to-date list, as policies may have been created or deleted since
+    the last call.
+
+    IMPORTANT — intermittent empty response: If this tool returns an empty
+    list but the user expects policies to exist, call it again — the API
+    occasionally returns an empty response on the first call after server
+    start. A retry will return the correct data.
+
     Returns:
         Dict containing:
             - policies (List[Dict]): List of device assurance policy objects.
+            - warning (str): Present if the API returned an unexpected empty
+              response; the caller should retry.
             - error (str): Error message if the operation fails.
     """
     logger.info("Listing device assurance policies")
@@ -190,15 +238,33 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             logger.error(f"Error listing device assurance policies: {err}")
             return {"error": str(err)}
 
-        if not policies:
+        # The SDK occasionally returns None on the first call after server start
+        # (auth initialisation race). Distinguish None (transient — advise retry)
+        # from an empty list (genuinely no policies configured).
+        if policies is None:
+            logger.warning(
+                "SDK returned None for list_device_assurance_policies — "
+                "likely a transient auth initialisation issue."
+            )
+            return {
+                "policies": [],
+                "warning": (
+                    "The API returned an unexpected empty response. "
+                    "If you expect policies to exist, please call this tool again."
+                ),
+            }
+
+        policy_list = list(policies)
+
+        if not policy_list:
             logger.info("No device assurance policies found")
             return {"policies": []}
 
-        logger.info(f"Successfully retrieved {len(policies)} device assurance policy(ies)")
+        logger.info(f"Successfully retrieved {len(policy_list)} device assurance policy(ies)")
         return {
             "policies": [
                 _enrich_policy_with_attribute_status(policy.to_dict())
-                for policy in policies
+                for policy in policy_list
             ]
         }
 
@@ -218,6 +284,12 @@ async def get_device_assurance_policy(
     (ANDROID, IOS, MACOS, WINDOWS, CHROMEOS), minimum OS version, disk
     encryption requirements, biometric lock settings, jailbreak/root
     detection, and any other compliance checks configured in the policy.
+
+    IMPORTANT — name-to-ID resolution: This tool requires a policy ID, not a
+    name. If the user refers to a policy by name, you MUST call
+    list_device_assurance_policies() first to get a FRESH, current list before
+    resolving the name to an ID. Never use a policy ID obtained from a previous
+    list call — new policies may have been created in the UI since then.
 
     Parameters:
         device_assurance_id (str, required): The ID of the device assurance policy.
@@ -285,6 +357,10 @@ async def create_device_assurance_policy(
         version_error = _validate_os_version(policy_data)
         if version_error:
             return {"error": version_error}
+
+        platform_error = _validate_platform_attributes(policy_data)
+        if platform_error:
+            return {"error": platform_error}
 
         okta_client = await get_okta_client(manager)
         policy_model = DeviceAssurance.from_dict(policy_data)
@@ -357,6 +433,10 @@ async def replace_device_assurance_policy(
         version_error = _validate_os_version(policy_data)
         if version_error:
             return {"error": version_error}
+
+        platform_error = _validate_platform_attributes(policy_data)
+        if platform_error:
+            return {"error": platform_error}
 
         okta_client = await get_okta_client(manager)
 

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -219,7 +219,8 @@ async def delete_device_assurance_policy(
 
     try:
         okta_client = await get_okta_client(manager)
-        _, _, err = await okta_client.delete_device_assurance_policy(device_assurance_id)
+        result = await okta_client.delete_device_assurance_policy(device_assurance_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error deleting device assurance policy {device_assurance_id}: {err}")

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -5,6 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import re
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
@@ -17,6 +18,150 @@ from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeleteConfirmation, elicit_or_fallback
 from okta_mcp_server.utils.messages import DELETE_DEVICE_ASSURANCE_POLICY
 from okta_mcp_server.utils.validation import validate_ids
+
+# Semantic version pattern: X.Y, X.Y.Z, or X.Y.Z.W (each component a non-negative integer)
+_SEMVER_PATTERN = re.compile(r"^\d+\.\d+(\.\d+(\.\d+)?)?$")
+
+# Matches two-component versions (X.Y) that need normalising to X.Y.0
+_TWO_COMPONENT_VERSION = re.compile(r"^\d+\.\d+$")
+
+# Security-relevant attributes that can be configured per platform.
+# If an attribute is expected for a platform but absent from the API response,
+# it means the organisation has NOT configured that check — not that it passed.
+# Note: These reflect API constraints after testing — not all listed attributes may be
+# accepted by the API for their respective platforms.
+_PLATFORM_SECURITY_ATTRIBUTES: Dict[str, List[str]] = {
+    "MACOS": ["osVersion", "diskEncryptionType", "screenLockType", "secureHardwarePresent"],
+    "WINDOWS": ["osVersion", "diskEncryptionType", "screenLockType", "secureHardwarePresent"],
+    "IOS": ["osVersion", "jailbreak", "screenLockType"],
+    "ANDROID": ["osVersion", "jailbreak", "screenLockType"],
+    "CHROMEOS": ["osVersion"],
+}
+
+
+def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
+    """Validate and normalise osVersion.minimum format if present.
+
+    Accepts X.Y, X.Y.Z, and X.Y.Z.W formats. Two-component versions (X.Y)
+    are automatically normalised to X.Y.0 in-place before being sent to the API.
+
+    Returns an error message string if validation fails, None if valid.
+    """
+    os_version = policy_data.get("osVersion") or policy_data.get("os_version")
+    if not os_version:
+        return None
+
+    minimum = os_version.get("minimum")
+    if not minimum:
+        return None
+
+    if not _SEMVER_PATTERN.match(minimum):
+        return (
+            f"Invalid OS version format: '{minimum}'. "
+            f"Version must be in X.Y, X.Y.Z, or X.Y.Z.W format "
+            f"(e.g., '14.2', '14.2.1', '14.2.1.0')."
+        )
+
+    # Normalise X.Y → X.Y.0 so the Okta API always receives a full three-component version.
+    if _TWO_COMPONENT_VERSION.match(minimum):
+        normalized = f"{minimum}.0"
+        logger.debug(f"Normalised OS version '{minimum}' → '{normalized}'")
+        os_version["minimum"] = normalized
+
+    return None
+
+
+def _enrich_policy_with_attribute_status(policy_dict: Dict[str, Any]) -> Dict[str, Any]:
+    """Add explicit security attribute status to a policy response.
+
+    For each security-relevant attribute on the policy's platform, marks it as
+    'configured' or 'not_configured'. This prevents ambiguity between
+    "the attribute was checked and found compliant" vs "the attribute was
+    never configured in this policy".
+    """
+    platform = policy_dict.get("platform")
+    if not platform:
+        return policy_dict
+
+    expected_attrs = _PLATFORM_SECURITY_ATTRIBUTES.get(platform, [])
+    attribute_status: Dict[str, str] = {}
+
+    for attr in expected_attrs:
+        value = policy_dict.get(attr)
+        if value is not None:
+            attribute_status[attr] = "configured"
+        else:
+            attribute_status[attr] = "not_configured"
+
+    policy_dict["securityAttributeStatus"] = attribute_status
+    return policy_dict
+
+
+def _compute_policy_diff(
+    before: Dict[str, Any], after: Dict[str, Any]
+) -> List[Dict[str, Any]]:
+    """Compute a structured diff between two policy states.
+
+    Returns a list of change dicts with attribute name, before/after values,
+    and a description of the security implication.
+    """
+    # Metadata keys to skip when comparing
+    skip_keys = {
+        "id", "createdBy", "createdDate", "lastUpdate", "lastUpdatedBy",
+        "_links", "links", "securityAttributeStatus",
+    }
+
+    changes: List[Dict[str, Any]] = []
+    all_keys = set(before.keys()) | set(after.keys())
+
+    for key in sorted(all_keys - skip_keys):
+        before_val = before.get(key)
+        after_val = after.get(key)
+
+        if before_val != after_val:
+            changes.append({
+                "attribute": key,
+                "before": before_val,
+                "after": after_val,
+                "implication": _get_implication(key, before_val, after_val),
+            })
+
+    return changes
+
+
+def _get_implication(attr: str, before: Any, after: Any) -> str:
+    """Return a human-readable security implication for a policy change."""
+    if attr == "osVersion":
+        return (
+            "Changes the minimum OS version requirement. Devices running "
+            "older versions will fail this assurance check."
+        )
+    if attr == "jailbreak":
+        if after:
+            return "Jailbroken/rooted devices will now be blocked."
+        return "Jailbroken/rooted devices will no longer be blocked by this policy."
+    if attr == "diskEncryptionType":
+        return (
+            "Changes disk encryption requirements. Devices not meeting "
+            "the new encryption standard will fail this assurance check."
+        )
+    if attr == "screenLockType":
+        return (
+            "Changes screen lock requirements. Devices without the required "
+            "screen lock type will fail this assurance check."
+        )
+    if attr == "secureHardwarePresent":
+        if after:
+            return "Devices must now have secure hardware (e.g., TPM) to pass this check."
+        return "Secure hardware is no longer required by this policy."
+    if attr == "name":
+        return "Policy display name updated."
+    if attr == "platform":
+        return (
+            "Target platform changed. This affects which devices "
+            "are evaluated against this policy."
+        )
+    return f"The '{attr}' setting has been modified."
 
 
 @mcp.tool()
@@ -50,7 +195,12 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             return {"policies": []}
 
         logger.info(f"Successfully retrieved {len(policies)} device assurance policy(ies)")
-        return {"policies": [policy.to_dict() for policy in policies]}
+        return {
+            "policies": [
+                _enrich_policy_with_attribute_status(policy.to_dict())
+                for policy in policies
+            ]
+        }
 
     except Exception as e:
         logger.error(f"Exception listing device assurance policies: {e}")
@@ -86,7 +236,9 @@ async def get_device_assurance_policy(
             logger.error(f"Error getting device assurance policy {device_assurance_id}: {err}")
             return {"error": str(err)}
 
-        return policy.to_dict() if policy else None
+        if not policy:
+            return None
+        return _enrich_policy_with_attribute_status(policy.to_dict())
 
     except Exception as e:
         logger.error(f"Exception getting device assurance policy {device_assurance_id}: {e}")
@@ -99,18 +251,29 @@ async def create_device_assurance_policy(
 ) -> Optional[Dict[str, Any]]:
     """Create a new Device Assurance Policy.
 
+    Platform-specific attribute support:
+        - ANDROID: name, platform, osVersion, jailbreak (false only), screenLockType
+        - IOS: name, platform, osVersion, jailbreak (false only), screenLockType
+        - MACOS: name, platform, osVersion, diskEncryptionType, screenLockType, secureHardwarePresent
+        - WINDOWS: name, platform, osVersion, diskEncryptionType, screenLockType, secureHardwarePresent
+        - CHROMEOS: name, platform, osVersion
+
     Parameters:
         policy_data (dict, required): The device assurance policy configuration.
             - name (str, required): The policy name.
             - platform (str, required): Target platform.
                 One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
             - osVersion (dict, optional): Minimum OS version requirements.
-                Example: {\"minimum\": \"14.0.0\"}
-            - diskEncryptionType (dict, optional): Required disk encryption types.
-            - secureHardwarePresent (bool, optional): Require secure hardware (e.g. TPM).
-            - screenLockType (dict, optional): Required screen lock types.
-            - jailbreak (bool, optional): Block jailbroken/rooted devices.
-            - thirdPartySignalProviders (dict, optional): Third-party signal providers config.
+                Format: {\"minimum\": \"X.Y.Z\"} where X.Y.Z is semantic version.
+                For ANDROID, use major version only: {\"minimum\": \"12\"}
+            - diskEncryptionType (dict, optional): Required disk encryption (MACOS, WINDOWS only).
+                Format: {\"type\": \"ALL_INTERNAL_VOLUMES\"}
+            - secureHardwarePresent (bool, optional): Require secure hardware (MACOS, WINDOWS only).
+            - screenLockType (dict, optional): Required screen lock type (ANDROID, IOS, MACOS, WINDOWS).
+                Format: {\"include\": [\"BIOMETRIC\"]} or {\"include\": [\"PASSCODE\", \"BIOMETRIC\"]}
+                Note: For ANDROID, [\"PASSCODE\"] alone is not valid — must include BIOMETRIC.
+            - jailbreak (bool, optional): Block jailbroken/rooted devices (IOS, ANDROID only).
+                Note: Currently only accepts false value.
 
     Returns:
         Dict containing the created policy details, or an error dict.
@@ -119,6 +282,10 @@ async def create_device_assurance_policy(
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
+        version_error = _validate_os_version(policy_data)
+        if version_error:
+            return {"error": version_error}
+
         okta_client = await get_okta_client(manager)
         policy_model = DeviceAssurance.from_dict(policy_data)
         policy, _, err = await okta_client.create_device_assurance_policy(policy_model)
@@ -146,6 +313,17 @@ async def replace_device_assurance_policy(
     compliance settings, or standardise policy configurations across your
     organisation.
 
+    Platform-specific attribute support:
+        - ANDROID: name, platform, osVersion, jailbreak (false only), screenLockType
+        - IOS: name, platform, osVersion, jailbreak (false only), screenLockType
+        - MACOS: name, platform, osVersion, diskEncryptionType, screenLockType, secureHardwarePresent
+        - WINDOWS: name, platform, osVersion, diskEncryptionType, screenLockType, secureHardwarePresent
+        - CHROMEOS: name, platform, osVersion
+
+    The response includes a "before" and "after" state comparison plus a
+    list of changes with security implications so the user can review what
+    changed before the update takes effect.
+
     Parameters:
         device_assurance_id (str, required): The ID of the policy to update.
         policy_data (dict, required): The complete updated policy configuration.
@@ -153,21 +331,49 @@ async def replace_device_assurance_policy(
             - platform (str, required): Target platform.
                 One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
             - osVersion (dict, optional): Minimum OS version requirements.
-                Example: {\"minimum\": \"14.2.1\"}
-            - diskEncryptionType (dict, optional): Required disk encryption types.
-            - secureHardwarePresent (bool, optional): Require secure hardware.
-            - screenLockType (dict, optional): Required screen lock types.
-            - jailbreak (bool, optional): Block jailbroken/rooted devices.
-            - thirdPartySignalProviders (dict, optional): Third-party signal providers config.
+                Format: {\"minimum\": \"X.Y.Z\"} where X.Y.Z is semantic version.
+                For ANDROID, use major version only: {\"minimum\": \"12\"}
+            - diskEncryptionType (dict, optional): Required disk encryption (MACOS, WINDOWS only).
+                Format: {\"type\": \"ALL_INTERNAL_VOLUMES\"}
+            - secureHardwarePresent (bool, optional): Require secure hardware (MACOS, WINDOWS only).
+            - screenLockType (dict, optional): Required screen lock type (ANDROID, IOS, MACOS, WINDOWS).
+                Format: {\"include\": [\"BIOMETRIC\"]} or {\"include\": [\"PASSCODE\", \"BIOMETRIC\"]}
+                Note: For ANDROID, [\"PASSCODE\"] alone is not valid — must include BIOMETRIC.
+            - jailbreak (bool, optional): Block jailbroken/rooted devices (IOS, ANDROID only).
+                Note: Currently only accepts false value.
 
     Returns:
-        Dict containing the updated policy details, or an error dict.
+        Dict containing:
+            - before (Dict): Policy state before the update (with securityAttributeStatus).
+            - after (Dict): Policy state after the update (with securityAttributeStatus).
+            - changes (List[Dict]): List of changed attributes, each with
+              attribute name, before/after values, and security implication.
+            - error (str): Error message if the operation fails.
     """
     logger.info(f"Replacing device assurance policy {device_assurance_id}")
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
     try:
+        version_error = _validate_os_version(policy_data)
+        if version_error:
+            return {"error": version_error}
+
         okta_client = await get_okta_client(manager)
+
+        # Fetch current state for before/after comparison
+        current_policy, _, fetch_err = await okta_client.get_device_assurance_policy(
+            device_assurance_id
+        )
+        if fetch_err:
+            logger.error(
+                f"Error fetching current device assurance policy {device_assurance_id}: {fetch_err}"
+            )
+            return {"error": str(fetch_err)}
+
+        before_state = _enrich_policy_with_attribute_status(
+            current_policy.to_dict()
+        ) if current_policy else {}
+
         policy_model = DeviceAssurance.from_dict(policy_data)
         policy, _, err = await okta_client.replace_device_assurance_policy(
             device_assurance_id, policy_model
@@ -177,8 +383,18 @@ async def replace_device_assurance_policy(
             logger.error(f"Error replacing device assurance policy {device_assurance_id}: {err}")
             return {"error": str(err)}
 
+        if not policy:
+            return None
+
+        after_state = _enrich_policy_with_attribute_status(policy.to_dict())
+        changes = _compute_policy_diff(before_state, after_state)
+
         logger.info(f"Successfully replaced device assurance policy {device_assurance_id}")
-        return policy.to_dict() if policy else None
+        return {
+            "before": before_state,
+            "after": after_state,
+            "changes": changes,
+        }
 
     except Exception as e:
         logger.error(f"Exception replacing device assurance policy {device_assurance_id}: {e}")

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -1,0 +1,236 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+from mcp.server.fastmcp import Context
+
+from okta.models.device_assurance import DeviceAssurance
+
+from okta_mcp_server.server import mcp
+from okta_mcp_server.utils.client import get_okta_client
+from okta_mcp_server.utils.elicitation import DeleteConfirmation, elicit_or_fallback
+from okta_mcp_server.utils.messages import DELETE_DEVICE_ASSURANCE_POLICY
+from okta_mcp_server.utils.validation import validate_ids
+
+
+@mcp.tool()
+async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
+    """List all Device Assurance Policies in the Okta organization.
+
+    Use this to audit which device assurance policies exist, compare OS
+    version requirements across policies, find policies that do or do not
+    block jailbroken/rooted devices, or identify policies whose platform
+    requirements may be outdated.
+
+    Returns:
+        Dict containing:
+            - policies (List[Dict]): List of device assurance policy objects.
+            - error (str): Error message if the operation fails.
+    """
+    logger.info("Listing device assurance policies")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        okta_client = await get_okta_client(manager)
+        policies, _, err = await okta_client.list_device_assurance_policies()
+
+        if err:
+            logger.error(f"Error listing device assurance policies: {err}")
+            return {"error": str(err)}
+
+        if not policies:
+            logger.info("No device assurance policies found")
+            return {"policies": []}
+
+        logger.info(f"Successfully retrieved {len(policies)} device assurance policy(ies)")
+        return {"policies": [policy.to_dict() for policy in policies]}
+
+    except Exception as e:
+        logger.error(f"Exception listing device assurance policies: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@validate_ids("device_assurance_id", error_return_type="dict")
+async def get_device_assurance_policy(
+    ctx: Context, device_assurance_id: str
+) -> Optional[Dict[str, Any]]:
+    """Retrieve a specific Device Assurance Policy by ID.
+
+    Use this to inspect the full configuration of a policy — platform type
+    (ANDROID, IOS, MACOS, WINDOWS, CHROMEOS), minimum OS version, disk
+    encryption requirements, biometric lock settings, jailbreak/root
+    detection, and any other compliance checks configured in the policy.
+
+    Parameters:
+        device_assurance_id (str, required): The ID of the device assurance policy.
+
+    Returns:
+        Dict containing the full policy details, or an error dict.
+    """
+    logger.info(f"Getting device assurance policy {device_assurance_id}")
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        okta_client = await get_okta_client(manager)
+        policy, _, err = await okta_client.get_device_assurance_policy(device_assurance_id)
+
+        if err:
+            logger.error(f"Error getting device assurance policy {device_assurance_id}: {err}")
+            return {"error": str(err)}
+
+        return policy.to_dict() if policy else None
+
+    except Exception as e:
+        logger.error(f"Exception getting device assurance policy {device_assurance_id}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def create_device_assurance_policy(
+    ctx: Context, policy_data: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Create a new Device Assurance Policy.
+
+    Parameters:
+        policy_data (dict, required): The device assurance policy configuration.
+            - name (str, required): The policy name.
+            - platform (str, required): Target platform.
+                One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
+            - osVersion (dict, optional): Minimum OS version requirements.
+                Example: {\"minimum\": \"14.0.0\"}
+            - diskEncryptionType (dict, optional): Required disk encryption types.
+            - secureHardwarePresent (bool, optional): Require secure hardware (e.g. TPM).
+            - screenLockType (dict, optional): Required screen lock types.
+            - jailbreak (bool, optional): Block jailbroken/rooted devices.
+            - thirdPartySignalProviders (dict, optional): Third-party signal providers config.
+
+    Returns:
+        Dict containing the created policy details, or an error dict.
+    """
+    logger.info("Creating new device assurance policy")
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        okta_client = await get_okta_client(manager)
+        policy_model = DeviceAssurance.from_dict(policy_data)
+        policy, _, err = await okta_client.create_device_assurance_policy(policy_model)
+
+        if err:
+            logger.error(f"Error creating device assurance policy: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully created device assurance policy {policy.id if policy else 'unknown'}")
+        return policy.to_dict() if policy else None
+
+    except Exception as e:
+        logger.error(f"Exception creating device assurance policy: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@validate_ids("device_assurance_id", error_return_type="dict")
+async def replace_device_assurance_policy(
+    ctx: Context, device_assurance_id: str, policy_data: Dict[str, Any]
+) -> Optional[Dict[str, Any]]:
+    """Replace (fully update) an existing Device Assurance Policy.
+
+    Use this to update minimum OS version requirements, change platform
+    compliance settings, or standardise policy configurations across your
+    organisation.
+
+    Parameters:
+        device_assurance_id (str, required): The ID of the policy to update.
+        policy_data (dict, required): The complete updated policy configuration.
+            - name (str, required): The policy name.
+            - platform (str, required): Target platform.
+                One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
+            - osVersion (dict, optional): Minimum OS version requirements.
+                Example: {\"minimum\": \"14.2.1\"}
+            - diskEncryptionType (dict, optional): Required disk encryption types.
+            - secureHardwarePresent (bool, optional): Require secure hardware.
+            - screenLockType (dict, optional): Required screen lock types.
+            - jailbreak (bool, optional): Block jailbroken/rooted devices.
+            - thirdPartySignalProviders (dict, optional): Third-party signal providers config.
+
+    Returns:
+        Dict containing the updated policy details, or an error dict.
+    """
+    logger.info(f"Replacing device assurance policy {device_assurance_id}")
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        okta_client = await get_okta_client(manager)
+        policy_model = DeviceAssurance.from_dict(policy_data)
+        policy, _, err = await okta_client.replace_device_assurance_policy(
+            device_assurance_id, policy_model
+        )
+
+        if err:
+            logger.error(f"Error replacing device assurance policy {device_assurance_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully replaced device assurance policy {device_assurance_id}")
+        return policy.to_dict() if policy else None
+
+    except Exception as e:
+        logger.error(f"Exception replacing device assurance policy {device_assurance_id}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@validate_ids("device_assurance_id", error_return_type="dict")
+async def delete_device_assurance_policy(
+    ctx: Context, device_assurance_id: str
+) -> Dict[str, Any]:
+    """Delete a Device Assurance Policy from the Okta organization.
+
+    The user will be asked for confirmation before the deletion proceeds.
+    Note: A policy that is currently assigned to an authentication policy
+    cannot be deleted.
+
+    Parameters:
+        device_assurance_id (str, required): The ID of the device assurance policy to delete.
+
+    Returns:
+        Dict with success status or cancellation message.
+    """
+    logger.warning(f"Deletion requested for device assurance policy {device_assurance_id}")
+
+    outcome = await elicit_or_fallback(
+        ctx,
+        message=DELETE_DEVICE_ASSURANCE_POLICY.format(policy_id=device_assurance_id),
+        schema=DeleteConfirmation,
+        auto_confirm_on_fallback=True,
+    )
+
+    if not outcome.confirmed:
+        logger.info(f"Device assurance policy deletion cancelled for {device_assurance_id}")
+        return {"message": "Device assurance policy deletion cancelled by user."}
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        okta_client = await get_okta_client(manager)
+        _, _, err = await okta_client.delete_device_assurance_policy(device_assurance_id)
+
+        if err:
+            logger.error(f"Error deleting device assurance policy {device_assurance_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Device assurance policy {device_assurance_id} deleted successfully")
+        return {
+            "success": True,
+            "message": f"Device assurance policy {device_assurance_id} deleted successfully",
+        }
+
+    except Exception as e:
+        logger.error(f"Exception deleting device assurance policy {device_assurance_id}: {e}")
+        return {"error": str(e)}

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from mcp.server.fastmcp import Context
-
+from okta.exceptions.exceptions import ForbiddenException, UnauthorizedException
 from okta.models.device_assurance import DeviceAssurance
 
 from okta_mcp_server.server import mcp
@@ -46,6 +46,52 @@ _PLATFORM_ONLY_ATTRIBUTES: Dict[str, List[str]] = {
     "jailbreak": ["ANDROID", "IOS"],
     "screenLockType": ["ANDROID", "IOS", "MACOS", "WINDOWS"],
 }
+
+
+def _build_scope_error(operation: str, status: int = 403) -> Dict[str, str]:
+    """Return a user-friendly error dict when the API rejects a request due to missing scope.
+
+    Args:
+        operation: Human-readable verb describing what was attempted
+                   (e.g. ``"list"``, ``"create"``, ``"delete"``).  Used to pick
+                   the appropriate scope hint.
+        status:    HTTP status code returned by Okta (typically 401 or 403).
+    """
+    if operation in ("create", "replace", "delete"):
+        scope_hint = "okta.deviceAssurance.manage"
+    else:
+        scope_hint = "okta.deviceAssurance.read"
+    return {
+        "error": (
+            f"The Okta API call was blocked by permissions (HTTP {status}). "
+            f"Missing required OAuth scope for Device Assurance Policies: '{scope_hint}'. "
+            f"First, check your MCP configuration (mcp.json) and ensure your OKTA_SCOPES includes '{scope_hint}'. "
+            f"Then grant the scope to your Okta OIDC app and re-authenticate before retrying."
+        )
+    }
+
+
+def _get_configured_scopes(manager: Any) -> Optional[set[str]]:
+    """Extract the configured OAuth scopes from the auth manager.
+
+    This is intentionally based on the *configured* scopes (OKTA_SCOPES / manager.scopes),
+    not the cached access token, to avoid coupling tool behavior to local keychain state
+    and to keep unit tests deterministic.
+
+    Returns:
+        - set[str] if scopes could be read
+        - None if the manager does not expose scopes (e.g., test doubles)
+    """
+    scopes_str = getattr(manager, "scopes", None)
+    if not scopes_str or not isinstance(scopes_str, str):
+        return None
+    return set(scopes_str.split())
+
+
+def _missing_required_scope(required_scope: str, manager: Any) -> bool:
+    """Return True when the configured scope set is known and missing the required scope."""
+    configured = _get_configured_scopes(manager)
+    return configured is not None and required_scope not in configured
 
 
 def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
@@ -225,23 +271,44 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             - warning (str): Present if the API returned an unexpected empty
               response; the caller should retry.
             - error (str): Error message if the operation fails.
+
+    Scope/permission errors:
+        If the Okta API returns HTTP 401/403 (commonly due to missing OAuth scopes),
+        this tool returns ``{"error": "..."}``.
+        In that case, present the error message verbatim and STOP — do not retry
+        and do not attempt follow-up actions until scopes are fixed.
     """
     logger.info("Listing device assurance policies")
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
 
+    # Scope precheck: if we can determine the token lacks the required scope,
+    # return the error immediately and do nothing else.
+    if _missing_required_scope("okta.deviceAssurance.read", manager):
+        return _build_scope_error("list", 403)
+
     try:
         okta_client = await get_okta_client(manager)
-        policies, _, err = await okta_client.list_device_assurance_policies()
+        policies, resp, err = await okta_client.list_device_assurance_policies()
 
         if err:
             logger.error(f"Error listing device assurance policies: {err}")
+            if hasattr(err, "status") and err.status in (401, 403):
+                return _build_scope_error("list", err.status)
             return {"error": str(err)}
 
         # The SDK occasionally returns None on the first call after server start
         # (auth initialisation race). Distinguish None (transient — advise retry)
         # from an empty list (genuinely no policies configured).
+        # A 4xx status with an empty body is also surfaced here — treat it as a
+        # permission/scope error rather than a transient issue.
         if policies is None:
+            if resp is not None and hasattr(resp, "status_code") and resp.status_code in (401, 403):
+                logger.error(
+                    f"list_device_assurance_policies returned HTTP {resp.status_code} "
+                    "with empty body — likely a missing scope."
+                )
+                return _build_scope_error("list", resp.status_code)
             logger.warning(
                 "SDK returned None for list_device_assurance_policies — "
                 "likely a transient auth initialisation issue."
@@ -268,6 +335,9 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             ]
         }
 
+    except (ForbiddenException, UnauthorizedException) as e:
+        logger.error(f"Access denied listing device assurance policies: {e}")
+        return _build_scope_error("list", e.status)
     except Exception as e:
         logger.error(f"Exception listing device assurance policies: {e}")
         return {"error": str(e)}
@@ -296,9 +366,18 @@ async def get_device_assurance_policy(
 
     Returns:
         Dict containing the full policy details, or an error dict.
+
+    Scope/permission errors:
+        If the Okta API returns HTTP 401/403 (commonly due to missing OAuth scopes),
+        this tool returns ``{"error": "..."}``.
+        In that case, present the error message verbatim and STOP — do not retry
+        and do not attempt follow-up actions until scopes are fixed.
     """
     logger.info(f"Getting device assurance policy {device_assurance_id}")
     manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    if _missing_required_scope("okta.deviceAssurance.read", manager):
+        return _build_scope_error("get", 403)
 
     try:
         okta_client = await get_okta_client(manager)
@@ -306,12 +385,17 @@ async def get_device_assurance_policy(
 
         if err:
             logger.error(f"Error getting device assurance policy {device_assurance_id}: {err}")
+            if hasattr(err, "status") and err.status in (401, 403):
+                return _build_scope_error("get", err.status)
             return {"error": str(err)}
 
         if not policy:
             return None
         return _enrich_policy_with_attribute_status(policy.to_dict())
 
+    except (ForbiddenException, UnauthorizedException) as e:
+        logger.error(f"Access denied getting device assurance policy {device_assurance_id}: {e}")
+        return _build_scope_error("get", e.status)
     except Exception as e:
         logger.error(f"Exception getting device assurance policy {device_assurance_id}: {e}")
         return {"error": str(e)}
@@ -349,9 +433,18 @@ async def create_device_assurance_policy(
 
     Returns:
         Dict containing the created policy details, or an error dict.
+
+    Scope/permission errors:
+        If the Okta API returns HTTP 401/403 (commonly due to missing OAuth scopes),
+        this tool returns ``{"error": "..."}``.
+        In that case, present the error message verbatim and STOP — do not retry
+        and do not attempt follow-up actions until scopes are fixed.
     """
     logger.info("Creating new device assurance policy")
     manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    if _missing_required_scope("okta.deviceAssurance.manage", manager):
+        return _build_scope_error("create", 403)
 
     try:
         version_error = _validate_os_version(policy_data)
@@ -368,11 +461,16 @@ async def create_device_assurance_policy(
 
         if err:
             logger.error(f"Error creating device assurance policy: {err}")
+            if hasattr(err, "status") and err.status in (401, 403):
+                return _build_scope_error("create", err.status)
             return {"error": str(err)}
 
         logger.info(f"Successfully created device assurance policy {policy.id if policy else 'unknown'}")
         return policy.to_dict() if policy else None
 
+    except (ForbiddenException, UnauthorizedException) as e:
+        logger.error(f"Access denied creating device assurance policy: {e}")
+        return _build_scope_error("create", e.status)
     except Exception as e:
         logger.error(f"Exception creating device assurance policy: {e}")
         return {"error": str(e)}
@@ -425,9 +523,18 @@ async def replace_device_assurance_policy(
             - changes (List[Dict]): List of changed attributes, each with
               attribute name, before/after values, and security implication.
             - error (str): Error message if the operation fails.
+
+    Scope/permission errors:
+        If the Okta API returns HTTP 401/403 (commonly due to missing OAuth scopes),
+        this tool returns ``{"error": "..."}``.
+        In that case, present the error message verbatim and STOP — do not retry
+        and do not attempt follow-up actions until scopes are fixed.
     """
     logger.info(f"Replacing device assurance policy {device_assurance_id}")
     manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    if _missing_required_scope("okta.deviceAssurance.manage", manager):
+        return _build_scope_error("replace", 403)
 
     try:
         version_error = _validate_os_version(policy_data)
@@ -448,6 +555,8 @@ async def replace_device_assurance_policy(
             logger.error(
                 f"Error fetching current device assurance policy {device_assurance_id}: {fetch_err}"
             )
+            if hasattr(fetch_err, "status") and fetch_err.status in (401, 403):
+                return _build_scope_error("replace", fetch_err.status)
             return {"error": str(fetch_err)}
 
         before_state = _enrich_policy_with_attribute_status(
@@ -461,6 +570,8 @@ async def replace_device_assurance_policy(
 
         if err:
             logger.error(f"Error replacing device assurance policy {device_assurance_id}: {err}")
+            if hasattr(err, "status") and err.status in (401, 403):
+                return _build_scope_error("replace", err.status)
             return {"error": str(err)}
 
         if not policy:
@@ -476,6 +587,9 @@ async def replace_device_assurance_policy(
             "changes": changes,
         }
 
+    except (ForbiddenException, UnauthorizedException) as e:
+        logger.error(f"Access denied replacing device assurance policy {device_assurance_id}: {e}")
+        return _build_scope_error("replace", e.status)
     except Exception as e:
         logger.error(f"Exception replacing device assurance policy {device_assurance_id}: {e}")
         return {"error": str(e)}
@@ -497,8 +611,21 @@ async def delete_device_assurance_policy(
 
     Returns:
         Dict with success status or cancellation message.
+
+    Scope/permission errors:
+        If the Okta API returns HTTP 401/403 (commonly due to missing OAuth scopes),
+        this tool returns ``{"error": "..."}``.
+        In that case, present the error message verbatim and STOP — do not retry
+        and do not attempt follow-up actions until scopes are fixed.
     """
     logger.warning(f"Deletion requested for device assurance policy {device_assurance_id}")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    # Scope precheck must happen before elicitation so we don't prompt for
+    # confirmation when the operation cannot succeed.
+    if _missing_required_scope("okta.deviceAssurance.manage", manager):
+        return _build_scope_error("delete", 403)
 
     outcome = await elicit_or_fallback(
         ctx,
@@ -511,8 +638,6 @@ async def delete_device_assurance_policy(
         logger.info(f"Device assurance policy deletion cancelled for {device_assurance_id}")
         return {"message": "Device assurance policy deletion cancelled by user."}
 
-    manager = ctx.request_context.lifespan_context.okta_auth_manager
-
     try:
         okta_client = await get_okta_client(manager)
         result = await okta_client.delete_device_assurance_policy(device_assurance_id)
@@ -520,6 +645,8 @@ async def delete_device_assurance_policy(
 
         if err:
             logger.error(f"Error deleting device assurance policy {device_assurance_id}: {err}")
+            if hasattr(err, "status") and err.status in (401, 403):
+                return _build_scope_error("delete", err.status)
             return {"error": str(err)}
 
         logger.info(f"Device assurance policy {device_assurance_id} deleted successfully")
@@ -528,6 +655,9 @@ async def delete_device_assurance_policy(
             "message": f"Device assurance policy {device_assurance_id} deleted successfully",
         }
 
+    except (ForbiddenException, UnauthorizedException) as e:
+        logger.error(f"Access denied deleting device assurance policy {device_assurance_id}: {e}")
+        return _build_scope_error("delete", e.status)
     except Exception as e:
         logger.error(f"Exception deleting device assurance policy {device_assurance_id}: {e}")
         return {"error": str(e)}

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -26,6 +26,9 @@ _SEMVER_PATTERN = re.compile(r"^\d+\.\d+(\.\d+(\.\d+)?)?$")
 # Matches two-component versions (X.Y) that need normalising to X.Y.0
 _TWO_COMPONENT_VERSION = re.compile(r"^\d+\.\d+$")
 
+# Matches single-component versions (X) — valid for Android major-only OS versions
+_SINGLE_COMPONENT_VERSION = re.compile(r"^\d+$")
+
 # Security-relevant attributes that can be configured per platform.
 # If an attribute is expected for a platform but absent from the API response,
 # it means the organisation has NOT configured that check — not that it passed.
@@ -101,6 +104,10 @@ def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
     Accepts X.Y, X.Y.Z, and X.Y.Z.W formats. Two-component versions (X.Y)
     are automatically normalised to X.Y.0 in-place before being sent to the API.
 
+    Android exception: single-component major versions (e.g. "12") are accepted
+    and passed through as-is — the Okta API expects the raw major version for Android
+    and rejects normalised forms like "12.0.0".
+
     Returns an error message string if validation fails, None if valid.
     """
     os_version = policy_data.get("osVersion") or policy_data.get("os_version")
@@ -111,11 +118,20 @@ def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
     if not minimum:
         return None
 
+    platform = (policy_data.get("platform") or "").upper()
+
+    # Android accepts single-component major versions (e.g. "12").
+    # The Okta API for Android expects the major version as-is (e.g. "12"), not "12.0.0".
+    if platform == "ANDROID" and _SINGLE_COMPONENT_VERSION.match(minimum):
+        logger.debug(f"Android OS version '{minimum}' accepted as-is (major version)")
+        return None
+
     if not _SEMVER_PATTERN.match(minimum):
         return (
             f"Invalid OS version format: '{minimum}'. "
             f"Version must be in X.Y, X.Y.Z, or X.Y.Z.W format "
-            f"(e.g., '14.2', '14.2.1', '14.2.1.0')."
+            f"(e.g., '14.2', '14.2.1', '14.2.1.0'). "
+            f"For Android, a major version only (e.g. '12') is also accepted."
         )
 
     # Normalise X.Y → X.Y.0 so the Okta API always receives a full three-component version.
@@ -143,6 +159,11 @@ def _validate_platform_attributes(policy_data: Dict[str, Any]) -> Optional[str]:
                 errors.append(
                     f"'{attr}' is not supported for {platform} — "
                     f"only available on: {', '.join(supported_platforms)}."
+                )
+            elif attr == "jailbreak" and policy_data.get(attr) is True:
+                errors.append(
+                    "The 'jailbreak' attribute currently only accepts the value false. "
+                    "Set jailbreak to false or omit the field entirely."
                 )
 
     if errors:

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -5,6 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
+import datetime
 import re
 from typing import Any, Dict, List, Optional
 
@@ -258,7 +259,10 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
     IMPORTANT — always call fresh: Never reuse results from a previous call
     to resolve a policy name to an ID. Always call this tool again to get
     an up-to-date list, as policies may have been created or deleted since
-    the last call.
+    the last call. The response includes a ``retrieved_at`` timestamp — if
+    the user references a policy by name that does not appear in a previous
+    list, you MUST call this tool again before concluding that the policy
+    does not exist.
 
     IMPORTANT — intermittent empty response: If this tool returns an empty
     list but the user expects policies to exist, call it again — the API
@@ -268,6 +272,10 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
     Returns:
         Dict containing:
             - policies (List[Dict]): List of device assurance policy objects.
+            - retrieved_at (str): ISO-8601 UTC timestamp of when this list
+              was fetched. Use this to detect stale data.
+            - note (str): Reminder that the list may become stale and must
+              be re-fetched before resolving a policy name to an ID.
             - warning (str): Present if the API returned an unexpected empty
               response; the caller should retry.
             - error (str): Error message if the operation fails.
@@ -315,9 +323,15 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             )
             return {
                 "policies": [],
+                "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
                 "warning": (
                     "The API returned an unexpected empty response. "
                     "If you expect policies to exist, please call this tool again."
+                ),
+                "note": (
+                    "This list was retrieved at the time shown in retrieved_at. "
+                    "Always call list_device_assurance_policies again before resolving "
+                    "a policy name to an ID — the list may have changed since it was last fetched."
                 ),
             }
 
@@ -325,14 +339,28 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
 
         if not policy_list:
             logger.info("No device assurance policies found")
-            return {"policies": []}
+            return {
+                "policies": [],
+                "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "note": (
+                    "This list was retrieved at the time shown in retrieved_at. "
+                    "Always call list_device_assurance_policies again before resolving "
+                    "a policy name to an ID — the list may have changed since it was last fetched."
+                ),
+            }
 
         logger.info(f"Successfully retrieved {len(policy_list)} device assurance policy(ies)")
         return {
             "policies": [
                 _enrich_policy_with_attribute_status(policy.to_dict())
                 for policy in policy_list
-            ]
+            ],
+            "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "note": (
+                "This list was retrieved at the time shown in retrieved_at. "
+                "Always call list_device_assurance_policies again before resolving "
+                "a policy name to an ID — the list may have changed since it was last fetched."
+            ),
         }
 
     except (ForbiddenException, UnauthorizedException) as e:
@@ -358,8 +386,12 @@ async def get_device_assurance_policy(
     IMPORTANT — name-to-ID resolution: This tool requires a policy ID, not a
     name. If the user refers to a policy by name, you MUST call
     list_device_assurance_policies() first to get a FRESH, current list before
-    resolving the name to an ID. Never use a policy ID obtained from a previous
-    list call — new policies may have been created in the UI since then.
+    resolving the name to an ID. NEVER resolve a policy name using results
+    already present in the conversation — those results may be stale. Even if
+    you called list_device_assurance_policies moments ago, call it again: a
+    policy may have been created in the Okta UI between that call and now.
+    Only after receiving the fresh list may you map the name to an ID and call
+    this tool.
 
     Parameters:
         device_assurance_id (str, required): The ID of the device assurance policy.

--- a/src/okta_mcp_server/tools/device_assurance/device_assurance.py
+++ b/src/okta_mcp_server/tools/device_assurance/device_assurance.py
@@ -6,28 +6,80 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import datetime
-import re
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from mcp.server.fastmcp import Context
 from okta.exceptions.exceptions import ForbiddenException, UnauthorizedException
 from okta.models.device_assurance import DeviceAssurance
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeleteConfirmation, elicit_or_fallback
 from okta_mcp_server.utils.messages import DELETE_DEVICE_ASSURANCE_POLICY
-from okta_mcp_server.utils.validation import validate_ids
+from okta_mcp_server.utils.validation import validate_ids, validate_os_version_params
 
-# Semantic version pattern: X.Y, X.Y.Z, or X.Y.Z.W (each component a non-negative integer)
-_SEMVER_PATTERN = re.compile(r"^\d+\.\d+(\.\d+(\.\d+)?)?$")
 
-# Matches two-component versions (X.Y) that need normalising to X.Y.0
-_TWO_COMPONENT_VERSION = re.compile(r"^\d+\.\d+$")
+# ---------------------------------------------------------------------------
+# Input types for create/replace tools
+#
+# Pydantic BaseModel with extra='forbid' so FastMCP will reject any field that
+# is not in the schema.  ``osVersion`` is intentionally absent: the OS version
+# is always supplied via the top-level ``user_stated_os_version`` parameter so
+# it is validated verbatim before being injected into the API payload.
+# The model_validator fires BEFORE the tool body runs, giving a clear error
+# message when the LLM tries to put osVersion inside policy_data.
+# ---------------------------------------------------------------------------
 
-# Matches single-component versions (X) — valid for Android major-only OS versions
-_SINGLE_COMPONENT_VERSION = re.compile(r"^\d+$")
+class _ScreenLockTypeInput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    include: Optional[List[str]] = None
+
+
+class _DiskEncryptionTypeInput(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    type: Optional[str] = None
+
+
+_OS_VERSION_IN_POLICY_DATA_ERROR = (
+    "osVersion must NOT be included in policy_data. "
+    "Pass the OS version as a separate parameter: user_stated_os_version. "
+    "Set user_stated_os_version to the EXACT characters the user typed — "
+    "do NOT normalize or append '.0'. "
+    "Then retry this call with osVersion removed from policy_data."
+)
+
+
+class PolicyDataInput(BaseModel):
+    """Accepted fields for create/replace. ``osVersion`` is intentionally excluded —
+    always pass the OS version via the ``user_stated_os_version`` parameter."""
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = None
+    platform: Optional[str] = None
+    diskEncryptionType: Optional[_DiskEncryptionTypeInput] = None
+    secureHardwarePresent: Optional[bool] = None
+    screenLockType: Optional[_ScreenLockTypeInput] = None
+    jailbreak: Optional[bool] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_os_version(cls, data: Any) -> Any:
+        """Intercept osVersion before Pydantic validates anything else.
+
+        This runs BEFORE the tool body, so the LLM sees a clear error
+        immediately rather than a silent strip or an API failure.
+        """
+        if isinstance(data, dict) and "osVersion" in data:
+            raise ValueError(_OS_VERSION_IN_POLICY_DATA_ERROR)
+        return data
+
+    def as_api_dict(self) -> Dict[str, Any]:
+        """Return a plain dict of set (non-None) fields, ready for the Okta API."""
+        return {k: v for k, v in self.model_dump().items() if v is not None}
+
+
 
 # Security-relevant attributes that can be configured per platform.
 # If an attribute is expected for a platform but absent from the API response,
@@ -98,51 +150,6 @@ def _missing_required_scope(required_scope: str, manager: Any) -> bool:
     return configured is not None and required_scope not in configured
 
 
-def _validate_os_version(policy_data: Dict[str, Any]) -> Optional[str]:
-    """Validate and normalise osVersion.minimum format if present.
-
-    Accepts X.Y, X.Y.Z, and X.Y.Z.W formats. Two-component versions (X.Y)
-    are automatically normalised to X.Y.0 in-place before being sent to the API.
-
-    Android exception: single-component major versions (e.g. "12") are accepted
-    and passed through as-is — the Okta API expects the raw major version for Android
-    and rejects normalised forms like "12.0.0".
-
-    Returns an error message string if validation fails, None if valid.
-    """
-    os_version = policy_data.get("osVersion") or policy_data.get("os_version")
-    if not os_version:
-        return None
-
-    minimum = os_version.get("minimum")
-    if not minimum:
-        return None
-
-    platform = (policy_data.get("platform") or "").upper()
-
-    # Android accepts single-component major versions (e.g. "12").
-    # The Okta API for Android expects the major version as-is (e.g. "12"), not "12.0.0".
-    if platform == "ANDROID" and _SINGLE_COMPONENT_VERSION.match(minimum):
-        logger.debug(f"Android OS version '{minimum}' accepted as-is (major version)")
-        return None
-
-    if not _SEMVER_PATTERN.match(minimum):
-        return (
-            f"Invalid OS version format: '{minimum}'. "
-            f"Version must be in X.Y, X.Y.Z, or X.Y.Z.W format "
-            f"(e.g., '14.2', '14.2.1', '14.2.1.0'). "
-            f"For Android, a major version only (e.g. '12') is also accepted."
-        )
-
-    # Normalise X.Y → X.Y.0 so the Okta API always receives a full three-component version.
-    if _TWO_COMPONENT_VERSION.match(minimum):
-        normalized = f"{minimum}.0"
-        logger.debug(f"Normalised OS version '{minimum}' → '{normalized}'")
-        os_version["minimum"] = normalized
-
-    return None
-
-
 def _validate_platform_attributes(policy_data: Dict[str, Any]) -> Optional[str]:
     """Validate that the requested attributes are supported by the given platform.
 
@@ -175,13 +182,26 @@ def _validate_platform_attributes(policy_data: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _enrich_policy_with_attribute_status(policy_dict: Dict[str, Any]) -> Dict[str, Any]:
+def _enrich_policy_with_attribute_status(
+    policy_dict: Dict[str, Any],
+    unverifiable_attrs: Optional[set[str]] = None,
+) -> Dict[str, Any]:
     """Add explicit security attribute status to a policy response.
 
     For each security-relevant attribute on the policy's platform, marks it as
-    'configured' or 'not_configured'. This prevents ambiguity between
-    "the attribute was checked and found compliant" vs "the attribute was
-    never configured in this policy".
+    ``'configured'``, ``'not_configured'``, or ``'unverifiable'``. This prevents
+    ambiguity between:
+    - "the attribute was checked and found compliant"
+    - "the attribute was never configured in this policy"
+    - "the attribute could not be verified due to a partial API failure" (AC4)
+
+    AC1: The policy ``status`` field (ACTIVE/INACTIVE) is always surfaced.
+    If absent from the API response, it is set to ``"UNKNOWN"`` so the LLM
+    can detect the gap rather than silently omitting it.
+
+    AC4: If ``unverifiable_attrs`` is provided, attributes in that set are marked
+    ``'unverifiable'`` rather than ``'not_configured'``, and a ``partial_failure``
+    section is added to the response listing them explicitly.
     """
     platform = policy_dict.get("platform")
     if not platform:
@@ -189,16 +209,61 @@ def _enrich_policy_with_attribute_status(policy_dict: Dict[str, Any]) -> Dict[st
 
     expected_attrs = _PLATFORM_SECURITY_ATTRIBUTES.get(platform, [])
     attribute_status: Dict[str, str] = {}
+    unverifiable_set = unverifiable_attrs or set()
 
     for attr in expected_attrs:
-        value = policy_dict.get(attr)
-        if value is not None:
+        if attr in unverifiable_set:
+            attribute_status[attr] = "unverifiable"
+        elif policy_dict.get(attr) is not None:
             attribute_status[attr] = "configured"
         else:
             attribute_status[attr] = "not_configured"
 
+    # AC4: Explicitly surface the list of unverifiable attributes so the LLM
+    # never misrepresents them as 'not configured'.
+    unverifiable_list = [a for a in expected_attrs if a in unverifiable_set]
+    if unverifiable_list:
+        policy_dict["partial_failure"] = {
+            "unverifiable_attributes": unverifiable_list,
+            "message": (
+                "The following security attributes could not be verified due to "
+                f"a partial API failure: {', '.join(unverifiable_list)}. "
+                "Their status is unknown — do not treat them as 'not configured'."
+            ),
+        }
+
+    # AC1: Always surface the policy activation status (ACTIVE / INACTIVE).
+    # If the SDK model omits it, set an explicit sentinel so the LLM can detect the gap.
+    if "status" not in policy_dict:
+        policy_dict["status"] = "UNKNOWN"
+
     policy_dict["securityAttributeStatus"] = attribute_status
     return policy_dict
+
+
+def _detect_unverifiable_attributes(policy_dict: Dict[str, Any], resp: Any) -> set[str]:
+    """Detect which security attributes could not be verified due to a partial API response.
+
+    A partial API failure is indicated when the HTTP response carries a 207
+    (Multi-Status) status code. In that case, security attributes that are absent
+    from the policy dict are considered *unverifiable* — they may be configured but
+    the API could not confirm their current values.
+
+    Returns:
+        A set of attribute names that are unverifiable. Empty set when no partial
+        failure is detected.
+    """
+    if resp is None:
+        return set()
+
+    status_code = getattr(resp, "status_code", None) or getattr(resp, "status", None)
+    if status_code != 207:
+        return set()
+
+    platform = policy_dict.get("platform", "")
+    expected_attrs = _PLATFORM_SECURITY_ATTRIBUTES.get(platform, [])
+    # In a partial (207) response, any absent expected attribute is unverifiable.
+    return {attr for attr in expected_attrs if policy_dict.get(attr) is None}
 
 
 def _compute_policy_diff(
@@ -269,13 +334,34 @@ def _get_implication(attr: str, before: Any, after: Any) -> str:
 
 
 @mcp.tool()
-async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
+@validate_os_version_params("version_threshold")
+async def list_device_assurance_policies(
+    ctx: Context, version_threshold: Optional[str] = None
+) -> Dict[str, Any]:
     """List all Device Assurance Policies in the Okta organization.
 
     Use this to audit which device assurance policies exist, compare OS
     version requirements across policies, find policies that do or do not
     block jailbroken/rooted devices, or identify policies whose platform
     requirements may be outdated.
+
+    *** MANDATORY — OS VERSION THRESHOLD QUERIES ***
+        Any time the user's request mentions a version number for filtering or
+        comparison (e.g. "older than 14.2", "below 14.2.1", "at least 13.x"):
+
+        1. You MUST pass that exact user-supplied string as ``version_threshold``.
+           WRONG: list_device_assurance_policies()                         ← bypasses validation
+           RIGHT: list_device_assurance_policies(version_threshold="<user value>") ← always pass through
+           NEVER call this tool with no arguments and then filter the result
+           yourself — that completely bypasses format validation.
+
+        2. If the version is rejected (e.g. because the patch component is
+           missing), relay the error word-for-word. STOP and ask the user:
+           "What is the exact full version in X.Y.Z format?" Do NOT guess
+           or complete the version yourself. Do NOT proceed until the user
+           explicitly confirms the full X.Y.Z version.
+
+        3. NEVER guess or infer what the user "probably" meant — always ask.
 
     IMPORTANT — always call fresh: Never reuse results from a previous call
     to resolve a policy name to an ID. Always call this tool again to get
@@ -293,6 +379,13 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
     Returns:
         Dict containing:
             - policies (List[Dict]): List of device assurance policy objects.
+              Each policy includes a ``status`` field (``ACTIVE``, ``INACTIVE``,
+              or ``UNKNOWN`` if the API did not return it). You MUST present this
+              field when listing or comparing policies so the user sees the current
+              activation state.
+            - version_threshold (str, optional): Echo of the validated threshold
+              when one was supplied. Use this value for any subsequent filtering
+              or comparison in your response.
             - retrieved_at (str): ISO-8601 UTC timestamp of when this list
               was fetched. Use this to detect stale data.
             - note (str): Reminder that the list may become stale and must
@@ -371,11 +464,13 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
             }
 
         logger.info(f"Successfully retrieved {len(policy_list)} device assurance policy(ies)")
-        return {
-            "policies": [
-                _enrich_policy_with_attribute_status(policy.to_dict())
-                for policy in policy_list
-            ],
+        enriched_policies = []
+        for policy in policy_list:
+            policy_dict = policy.to_dict()
+            unverifiable = _detect_unverifiable_attributes(policy_dict, resp)
+            enriched_policies.append(_enrich_policy_with_attribute_status(policy_dict, unverifiable))
+        result: Dict[str, Any] = {
+            "policies": enriched_policies,
             "retrieved_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "note": (
                 "This list was retrieved at the time shown in retrieved_at. "
@@ -383,6 +478,9 @@ async def list_device_assurance_policies(ctx: Context) -> Dict[str, Any]:
                 "a policy name to an ID — the list may have changed since it was last fetched."
             ),
         }
+        if version_threshold is not None:
+            result["version_threshold"] = version_threshold
+        return result
 
     except (ForbiddenException, UnauthorizedException) as e:
         logger.error(f"Access denied listing device assurance policies: {e}")
@@ -434,7 +532,7 @@ async def get_device_assurance_policy(
 
     try:
         okta_client = await get_okta_client(manager)
-        policy, _, err = await okta_client.get_device_assurance_policy(device_assurance_id)
+        policy, resp, err = await okta_client.get_device_assurance_policy(device_assurance_id)
 
         if err:
             logger.error(f"Error getting device assurance policy {device_assurance_id}: {err}")
@@ -444,7 +542,9 @@ async def get_device_assurance_policy(
 
         if not policy:
             return None
-        return _enrich_policy_with_attribute_status(policy.to_dict())
+        policy_dict = policy.to_dict()
+        unverifiable = _detect_unverifiable_attributes(policy_dict, resp)
+        return _enrich_policy_with_attribute_status(policy_dict, unverifiable)
 
     except (ForbiddenException, UnauthorizedException) as e:
         logger.error(f"Access denied getting device assurance policy {device_assurance_id}: {e}")
@@ -455,10 +555,21 @@ async def get_device_assurance_policy(
 
 
 @mcp.tool()
+@validate_os_version_params("user_stated_os_version")
 async def create_device_assurance_policy(
-    ctx: Context, policy_data: Dict[str, Any]
+    ctx: Context, policy_data: PolicyDataInput, user_stated_os_version: Optional[str] = None
 ) -> Optional[Dict[str, Any]]:
     """Create a new Device Assurance Policy.
+
+    *** MANDATORY — OS VERSION ***
+        If the policy requires a minimum OS version:
+        a. Do NOT put osVersion inside policy_data — the tool constructs it
+           from user_stated_os_version after validation.
+        b. Set user_stated_os_version to the EXACT characters the user typed,
+           verbatim. NEVER invent or complete the version. "12.1" and
+           "12.1.0" are NOT the same — never append a patch number yourself.
+        c. If user_stated_os_version is rejected, relay the error and ask:
+           "What is the exact full version in X.Y.Z format?"
 
     Platform-specific attribute support:
         - ANDROID: name, platform, osVersion, jailbreak (false only), screenLockType
@@ -472,9 +583,7 @@ async def create_device_assurance_policy(
             - name (str, required): The policy name.
             - platform (str, required): Target platform.
                 One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
-            - osVersion (dict, optional): Minimum OS version requirements.
-                Format: {\"minimum\": \"X.Y.Z\"} where X.Y.Z is semantic version.
-                For ANDROID, use major version only: {\"minimum\": \"12\"}
+            - osVersion: Do NOT include — use user_stated_os_version instead.
             - diskEncryptionType (dict, optional): Required disk encryption (MACOS, WINDOWS only).
                 Format: {\"type\": \"ALL_INTERNAL_VOLUMES\"}
             - secureHardwarePresent (bool, optional): Require secure hardware (MACOS, WINDOWS only).
@@ -483,6 +592,10 @@ async def create_device_assurance_policy(
                 Note: For ANDROID, [\"PASSCODE\"] alone is not valid — must include BIOMETRIC.
             - jailbreak (bool, optional): Block jailbroken/rooted devices (IOS, ANDROID only).
                 Note: Currently only accepts false value.
+        user_stated_os_version (str, optional): The EXACT OS version string the user
+            typed, character-for-character. Required when setting a minimum OS version.
+            For ANDROID a single major version (e.g. "12") is accepted.
+            For all other platforms X.Y.Z is required — X.Y alone will be rejected.
 
     Returns:
         Dict containing the created policy details, or an error dict.
@@ -500,16 +613,24 @@ async def create_device_assurance_policy(
         return _build_scope_error("create", 403)
 
     try:
-        version_error = _validate_os_version(policy_data)
-        if version_error:
-            return {"error": version_error}
+        # AC2: Intercept osVersion when the function is called directly (e.g. in tests)
+        # without going through Pydantic/FastMCP.  In production FastMCP calls, the
+        # PolicyDataInput model_validator fires first and the function is never reached
+        # if osVersion is present.
+        raw = policy_data if isinstance(policy_data, dict) else policy_data.as_api_dict()
+        if raw.get("osVersion") and user_stated_os_version is None:
+            return {"error": _OS_VERSION_IN_POLICY_DATA_ERROR}
 
-        platform_error = _validate_platform_attributes(policy_data)
+        # Inject the verbatim-validated version into the API payload.
+        if user_stated_os_version:
+            raw = {**raw, "osVersion": {"minimum": user_stated_os_version}}
+
+        platform_error = _validate_platform_attributes(raw)
         if platform_error:
             return {"error": platform_error}
 
         okta_client = await get_okta_client(manager)
-        policy_model = DeviceAssurance.from_dict(policy_data)
+        policy_model = DeviceAssurance.from_dict(raw)
         policy, _, err = await okta_client.create_device_assurance_policy(policy_model)
 
         if err:
@@ -531,10 +652,31 @@ async def create_device_assurance_policy(
 
 @mcp.tool()
 @validate_ids("device_assurance_id", error_return_type="dict")
+@validate_os_version_params("user_stated_os_version")
 async def replace_device_assurance_policy(
-    ctx: Context, device_assurance_id: str, policy_data: Dict[str, Any]
+    ctx: Context, device_assurance_id: str, policy_data: PolicyDataInput,
+    user_stated_os_version: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Replace (fully update) an existing Device Assurance Policy.
+
+    *** MANDATORY RESPONSE FORMAT — YOU MUST FOLLOW THIS EVERY TIME ***
+        This tool ALWAYS returns ``"before"``, ``"after"``, and ``"changes"``
+        fields. After every successful call you MUST:
+        1. Present a formatted before/after comparison table to the user.
+        2. For every entry in ``"changes"``, show the attribute name,
+           old value, new value, and the ``"implication"`` string.
+        3. NEVER reply with just "Done" or a one-line summary.
+           The user must see the full comparison — always.
+        4. OS VERSION — always use ``user_stated_os_version`` parameter:
+           a. Do NOT put osVersion in policy_data — the tool derives it from
+              user_stated_os_version after validation.
+           b. Set user_stated_os_version to the EXACT characters the user
+              typed, verbatim. NEVER invent or complete the version. "X.Y" and
+              "X.Y.0" are NOT the same — never append a patch number yourself.
+           c. If user_stated_os_version is rejected, relay the error — STOP and ask:
+              "What is the exact full version in X.Y.Z format?"
+           d. Do NOT call this tool until the user explicitly states the full
+              X.Y.Z version.
 
     Use this to update minimum OS version requirements, change platform
     compliance settings, or standardise policy configurations across your
@@ -547,9 +689,11 @@ async def replace_device_assurance_policy(
         - WINDOWS: name, platform, osVersion, diskEncryptionType, screenLockType, secureHardwarePresent
         - CHROMEOS: name, platform, osVersion
 
-    The response includes a "before" and "after" state comparison plus a
-    list of changes with security implications so the user can review what
-    changed before the update takes effect.
+    The response ALWAYS includes ``"before"`` and ``"after"`` state comparisons
+    plus a ``"changes"`` list with security implications for each modified attribute.
+    You MUST present this as a formatted confirmation summary to the user, showing
+    exactly what changed and its security implication. Never simply say "Done" —
+    always display the before/after comparison table.
 
     Parameters:
         device_assurance_id (str, required): The ID of the policy to update.
@@ -557,9 +701,7 @@ async def replace_device_assurance_policy(
             - name (str, required): The policy name.
             - platform (str, required): Target platform.
                 One of: ANDROID, IOS, MACOS, WINDOWS, CHROMEOS.
-            - osVersion (dict, optional): Minimum OS version requirements.
-                Format: {\"minimum\": \"X.Y.Z\"} where X.Y.Z is semantic version.
-                For ANDROID, use major version only: {\"minimum\": \"12\"}
+            - osVersion: Do NOT include — use user_stated_os_version instead.
             - diskEncryptionType (dict, optional): Required disk encryption (MACOS, WINDOWS only).
                 Format: {\"type\": \"ALL_INTERNAL_VOLUMES\"}
             - secureHardwarePresent (bool, optional): Require secure hardware (MACOS, WINDOWS only).
@@ -568,6 +710,10 @@ async def replace_device_assurance_policy(
                 Note: For ANDROID, [\"PASSCODE\"] alone is not valid — must include BIOMETRIC.
             - jailbreak (bool, optional): Block jailbroken/rooted devices (IOS, ANDROID only).
                 Note: Currently only accepts false value.
+        user_stated_os_version (str, optional): The EXACT OS version string the user
+            typed, character-for-character. Required when changing the minimum OS version.
+            For ANDROID a single major version (e.g. "12") is accepted.
+            For all other platforms X.Y.Z is required — X.Y alone will be rejected.
 
     Returns:
         Dict containing:
@@ -590,18 +736,23 @@ async def replace_device_assurance_policy(
         return _build_scope_error("replace", 403)
 
     try:
-        version_error = _validate_os_version(policy_data)
-        if version_error:
-            return {"error": version_error}
+        # AC2: same guard as create — intercept osVersion in direct-call paths.
+        raw = policy_data if isinstance(policy_data, dict) else policy_data.as_api_dict()
+        if raw.get("osVersion") and user_stated_os_version is None:
+            return {"error": _OS_VERSION_IN_POLICY_DATA_ERROR}
 
-        platform_error = _validate_platform_attributes(policy_data)
+        # Inject the verbatim-validated version into the API payload.
+        if user_stated_os_version:
+            raw = {**raw, "osVersion": {"minimum": user_stated_os_version}}
+
+        platform_error = _validate_platform_attributes(raw)
         if platform_error:
             return {"error": platform_error}
 
         okta_client = await get_okta_client(manager)
 
         # Fetch current state for before/after comparison
-        current_policy, _, fetch_err = await okta_client.get_device_assurance_policy(
+        current_policy, fetch_resp, fetch_err = await okta_client.get_device_assurance_policy(
             device_assurance_id
         )
         if fetch_err:
@@ -612,12 +763,17 @@ async def replace_device_assurance_policy(
                 return _build_scope_error("replace", fetch_err.status)
             return {"error": str(fetch_err)}
 
-        before_state = _enrich_policy_with_attribute_status(
-            current_policy.to_dict()
-        ) if current_policy else {}
+        before_dict = current_policy.to_dict() if current_policy else {}
+        before_unverifiable = (
+            _detect_unverifiable_attributes(before_dict, fetch_resp) if current_policy else set()
+        )
+        before_state = (
+            _enrich_policy_with_attribute_status(before_dict, before_unverifiable)
+            if current_policy else {}
+        )
 
-        policy_model = DeviceAssurance.from_dict(policy_data)
-        policy, _, err = await okta_client.replace_device_assurance_policy(
+        policy_model = DeviceAssurance.from_dict(raw)
+        policy, replace_resp, err = await okta_client.replace_device_assurance_policy(
             device_assurance_id, policy_model
         )
 
@@ -630,7 +786,9 @@ async def replace_device_assurance_policy(
         if not policy:
             return None
 
-        after_state = _enrich_policy_with_attribute_status(policy.to_dict())
+        after_dict = policy.to_dict()
+        after_unverifiable = _detect_unverifiable_attributes(after_dict, replace_resp)
+        after_state = _enrich_policy_with_attribute_status(after_dict, after_unverifiable)
         changes = _compute_policy_diff(before_state, after_state)
 
         logger.info(f"Successfully replaced device assurance policy {device_assurance_id}")
@@ -638,6 +796,12 @@ async def replace_device_assurance_policy(
             "before": before_state,
             "after": after_state,
             "changes": changes,
+            "_display_required": (
+                "MANDATORY: Present 'before' and 'after' as a comparison table. "
+                "For every entry in 'changes', show: attribute name, before value, "
+                "after value, and implication. "
+                "Do NOT respond with 'Done' or a brief summary."
+            ),
         }
 
     except (ForbiddenException, UnauthorizedException) as e:

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -76,7 +76,7 @@ async def list_groups(
         query_params = build_query_params(search=search, filter=filter, q=q, after=after, limit=limit)
 
         logger.debug("Calling Okta API to list groups")
-        groups, response, err = await client.list_groups(query_params)
+        groups, response, err = await client.list_groups(**query_params)
 
         if err:
             logger.error(f"Okta API error while listing groups: {err}")
@@ -161,7 +161,7 @@ async def create_group(profile: dict, ctx: Context = None) -> list:
         # Wrap the profile in a dict with 'profile' key as required by Okta SDK
         logger.debug("Calling Okta API to create group")
 
-        group, _, err = await client.create_group({"profile": profile})
+        group, _, err = await client.add_group({"profile": profile})
 
         if err:
             logger.error(f"Okta API error while creating group: {err}")
@@ -224,7 +224,7 @@ async def delete_group(group_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete group {group_id}")
 
-        _, err = await client.delete_group(group_id)
+        _, _, err = await client.delete_group(group_id)
 
         if err:
             logger.error(f"Okta API error while deleting group {group_id}: {err}")
@@ -269,7 +269,7 @@ async def confirm_delete_group(group_id: str, confirmation: str, ctx: Context = 
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete group {group_id}")
 
-        _, err = await client.delete_group(group_id)
+        _, _, err = await client.delete_group(group_id)
 
         if err:
             logger.error(f"Okta API error while deleting group {group_id}: {err}")
@@ -306,7 +306,7 @@ async def update_group(group_id: str, profile: dict, ctx: Context = None) -> lis
         # Wrap the profile in a dict with 'profile' key as required by Okta SDK
         logger.debug(f"Calling Okta API to update group {group_id}")
 
-        group, _, err = await client.update_group(group_id, {"profile": profile})
+        group, _, err = await client.replace_group(group_id, {"profile": profile})
 
         if err:
             logger.error(f"Okta API error while updating group {group_id}: {err}")
@@ -372,7 +372,7 @@ async def list_group_users(
         logger.debug(f"Calling Okta API to list users in group {group_id}")
 
         query_params = build_query_params(after=after, limit=limit)
-        users, response, err = await client.list_group_users(group_id, query_params)
+        users, response, err = await client.list_group_users(group_id, **query_params)
 
         if err:
             logger.error(f"Okta API error while listing group users for {group_id}: {err}")
@@ -458,7 +458,7 @@ async def add_user_to_group(group_id: str, user_id: str, ctx: Context = None) ->
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to add user {user_id} to group {group_id}")
 
-        _, err = await client.add_user_to_group(group_id, user_id)
+        _, _, err = await client.assign_user_to_group(group_id, user_id)
 
         if err:
             logger.error(f"Okta API error while adding user {user_id} to group {group_id}: {err}")
@@ -493,7 +493,7 @@ async def remove_user_from_group(group_id: str, user_id: str, ctx: Context = Non
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to remove user {user_id} from group {group_id}")
 
-        _, err = await client.remove_user_from_group(group_id, user_id)
+        _, _, err = await client.unassign_user_from_group(group_id, user_id)
 
         if err:
             logger.error(f"Okta API error while removing user {user_id} from group {group_id}: {err}")

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -224,7 +224,8 @@ async def delete_group(group_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete group {group_id}")
 
-        _, _, err = await client.delete_group(group_id)
+        result = await client.delete_group(group_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deleting group {group_id}: {err}")
@@ -269,7 +270,8 @@ async def confirm_delete_group(group_id: str, confirmation: str, ctx: Context = 
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete group {group_id}")
 
-        _, _, err = await client.delete_group(group_id)
+        result = await client.delete_group(group_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deleting group {group_id}: {err}")
@@ -458,7 +460,8 @@ async def add_user_to_group(group_id: str, user_id: str, ctx: Context = None) ->
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to add user {user_id} to group {group_id}")
 
-        _, _, err = await client.assign_user_to_group(group_id, user_id)
+        result = await client.assign_user_to_group(group_id, user_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while adding user {user_id} to group {group_id}: {err}")
@@ -493,7 +496,8 @@ async def remove_user_from_group(group_id: str, user_id: str, ctx: Context = Non
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to remove user {user_id} from group {group_id}")
 
-        _, _, err = await client.unassign_user_from_group(group_id, user_id)
+        result = await client.unassign_user_from_group(group_id, user_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while removing user {user_id} from group {group_id}: {err}")

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -167,9 +167,9 @@ async def create_group(profile: dict, ctx: Context = None) -> list:
             logger.error(f"Okta API error while creating group: {err}")
             return {"error": f"Error: {err}"}
 
-        logger.info(
-            f"Successfully created group: {group.id} ({group.profile.name if hasattr(group, 'profile') else 'N/A'})"
-        )
+        profile_instance = getattr(group.profile, "actual_instance", None) if hasattr(group, "profile") else None
+        group_name = getattr(profile_instance, "name", "N/A") if profile_instance is not None else "N/A"
+        logger.info(f"Successfully created group: {group.id} ({group_name})")
         return [group]
     except Exception as e:
         logger.error(f"Exception while creating group: {type(e).__name__}: {e}")

--- a/src/okta_mcp_server/tools/groups/groups.py
+++ b/src/okta_mcp_server/tools/groups/groups.py
@@ -14,7 +14,7 @@ from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeleteConfirmation, elicit_or_fallback
 from okta_mcp_server.utils.messages import DELETE_GROUP
-from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, extract_after_cursor, paginate_all_results
 from okta_mcp_server.utils.validation import validate_ids
 
 
@@ -86,9 +86,13 @@ async def list_groups(
             logger.info("No groups found")
             return create_paginated_response([], response, fetch_all)
 
-        if fetch_all and response and hasattr(response, "has_next") and response.has_next():
+        if fetch_all and response and extract_after_cursor(response):
             logger.info(f"fetch_all=True, auto-paginating from initial {len(groups)} groups")
-            all_groups, pagination_info = await paginate_all_results(response, groups)
+            all_groups, pagination_info = await paginate_all_results(
+                response,
+                groups,
+                fetch_page_fn=lambda after: client.list_groups(**{**query_params, "after": after}),
+            )
 
             logger.info(
                 f"Successfully retrieved {len(all_groups)} groups across {pagination_info['pages_fetched']} pages"
@@ -384,9 +388,13 @@ async def list_group_users(
             logger.info(f"No users found in group {group_id}")
             return create_paginated_response([], response, fetch_all)
 
-        if fetch_all and response and hasattr(response, "has_next") and response.has_next():
+        if fetch_all and response and extract_after_cursor(response):
             logger.info(f"fetch_all=True, auto-paginating from initial {len(users)} users in group {group_id}")
-            all_users, pagination_info = await paginate_all_results(response, users)
+            all_users, pagination_info = await paginate_all_results(
+                response,
+                users,
+                fetch_page_fn=lambda after: client.list_group_users(group_id, **{**query_params, "after": after}),
+            )
 
             pages_fetched = pagination_info["pages_fetched"]
             logger.info(

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, Optional
 from loguru import logger
 from mcp.server.fastmcp import Context
 
+from okta.models.policy_rule import PolicyRule
+
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeactivateConfirmation, DeleteConfirmation, elicit_or_fallback
@@ -395,7 +397,8 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
     okta_client = await get_okta_client(manager)
 
     try:
-        rule, _, err = await okta_client.create_policy_rule(policy_id, rule_data)
+        policy_rule = PolicyRule.from_dict(rule_data)
+        rule, _, err = await okta_client.create_policy_rule(policy_id, policy_rule)
 
         if err:
             logger.error(f"Error creating policy rule: {err}")
@@ -427,7 +430,8 @@ async def update_policy_rule(
     okta_client = await get_okta_client(manager)
 
     try:
-        rule, _, err = await okta_client.replace_policy_rule(policy_id, rule_id, rule_data)
+        policy_rule = PolicyRule.from_dict(rule_data)
+        rule, _, err = await okta_client.replace_policy_rule(policy_id, rule_id, policy_rule)
 
         if err:
             logger.error(f"Error updating policy rule: {err}")

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -13,6 +13,7 @@ from mcp.server.fastmcp import Context
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeactivateConfirmation, DeleteConfirmation, elicit_or_fallback
+from okta_mcp_server.utils.pagination import extract_after_cursor
 from okta_mcp_server.utils.messages import (
     DEACTIVATE_POLICY,
     DEACTIVATE_POLICY_RULE,
@@ -70,9 +71,11 @@ async def list_policies(
             params["q"] = q
         if after:
             params["after"] = after
+        if "limit" in params and params["limit"] is not None:
+            params["limit"] = str(params["limit"])
 
         logger.debug("Calling Okta API to list policies")
-        policies, _, err = await okta_client.list_policies(params)
+        policies, _, err = await okta_client.list_policies(**params)
 
         if err:
             logger.error(f"Error listing policies: {err}")
@@ -84,7 +87,7 @@ async def list_policies(
 
         logger.info(f"Successfully retrieved {len(policies)} policies")
         return {
-            "policies": [policy.as_dict() for policy in policies],
+            "policies": [policy.to_dict() for policy in policies],
         }
 
     except Exception as e:
@@ -113,7 +116,7 @@ async def get_policy(ctx: Context, policy_id: str) -> Optional[Dict[str, Any]]:
             logger.error(f"Error getting policy {policy_id}: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return policy.to_dict() if policy else None
 
     except Exception as e:
         logger.error(f"Exception getting policy: {e}")
@@ -148,7 +151,7 @@ async def create_policy(ctx: Context, policy_data: Dict[str, Any]) -> Optional[D
             logger.error(f"Error creating policy: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return policy.to_dict() if policy else None
 
     except Exception as e:
         logger.error(f"Exception creating policy: {e}")
@@ -171,13 +174,13 @@ async def update_policy(ctx: Context, policy_id: str, policy_data: Dict[str, Any
     okta_client = await get_okta_client(manager)
 
     try:
-        policy, _, err = await okta_client.update_policy(policy_id, policy_data)
+        policy, _, err = await okta_client.replace_policy(policy_id, policy_data)
 
         if err:
             logger.error(f"Error updating policy {policy_id}: {err}")
             return {"error": str(err)}
 
-        return policy.as_dict() if policy else None
+        return policy.to_dict() if policy else None
 
     except Exception as e:
         logger.error(f"Exception updating policy: {e}")
@@ -214,7 +217,7 @@ async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
     try:
         okta_client = await get_okta_client(manager)
-        _, err = await okta_client.delete_policy(policy_id)
+        _, _, err = await okta_client.delete_policy(policy_id)
 
         if err:
             logger.error(f"Error deleting policy {policy_id}: {err}")
@@ -242,7 +245,7 @@ async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     okta_client = await get_okta_client(manager)
 
     try:
-        _, err = await okta_client.activate_policy(policy_id)
+        _, _, err = await okta_client.activate_policy(policy_id)
 
         if err:
             logger.error(f"Error activating policy {policy_id}: {err}")
@@ -285,7 +288,7 @@ async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
     try:
         okta_client = await get_okta_client(manager)
-        _, err = await okta_client.deactivate_policy(policy_id)
+        _, _, err = await okta_client.deactivate_policy(policy_id)
 
         if err:
             logger.error(f"Error deactivating policy {policy_id}: {err}")
@@ -327,10 +330,11 @@ async def list_policy_rules(ctx: Context, policy_id: str) -> Dict[str, Any]:
             logger.info("No policy rules found")
             return {"rules": []}
 
+        next_cursor = extract_after_cursor(resp)
         return {
-            "rules": [rule.as_dict() for rule in rules],
-            "has_next": resp.has_next() if resp else False,
-            "next_page_token": resp.get_next_page_token() if resp and resp.has_next() else None,
+            "rules": [rule.to_dict() for rule in rules],
+            "has_next": bool(next_cursor),
+            "next_page_token": next_cursor,
         }
 
     except Exception as e:
@@ -360,7 +364,7 @@ async def get_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Optiona
             logger.error(f"Error getting policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return rule.to_dict() if rule else None
 
     except Exception as e:
         logger.error(f"Exception getting policy rule: {e}")
@@ -394,7 +398,7 @@ async def create_policy_rule(ctx: Context, policy_id: str, rule_data: Dict[str, 
             logger.error(f"Error creating policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return rule.to_dict() if rule else None
 
     except Exception as e:
         logger.error(f"Exception creating policy rule: {e}")
@@ -420,13 +424,13 @@ async def update_policy_rule(
     okta_client = await get_okta_client(manager)
 
     try:
-        rule, _, err = await okta_client.update_policy_rule(policy_id, rule_id, rule_data)
+        rule, _, err = await okta_client.replace_policy_rule(policy_id, rule_id, rule_data)
 
         if err:
             logger.error(f"Error updating policy rule: {err}")
             return {"error": str(err)}
 
-        return rule.as_dict() if rule else None
+        return rule.to_dict() if rule else None
 
     except Exception as e:
         logger.error(f"Exception updating policy rule: {e}")
@@ -464,7 +468,7 @@ async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict
 
     try:
         okta_client = await get_okta_client(manager)
-        _, err = await okta_client.delete_policy_rule(policy_id, rule_id)
+        _, _, err = await okta_client.delete_policy_rule(policy_id, rule_id)
 
         if err:
             logger.error(f"Error deleting policy rule: {err}")
@@ -493,7 +497,7 @@ async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Di
     okta_client = await get_okta_client(manager)
 
     try:
-        _, err = await okta_client.activate_policy_rule(policy_id, rule_id)
+        _, _, err = await okta_client.activate_policy_rule(policy_id, rule_id)
 
         if err:
             logger.error(f"Error activating policy rule: {err}")
@@ -535,7 +539,7 @@ async def deactivate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> 
 
     try:
         okta_client = await get_okta_client(manager)
-        _, err = await okta_client.deactivate_policy_rule(policy_id, rule_id)
+        _, _, err = await okta_client.deactivate_policy_rule(policy_id, rule_id)
 
         if err:
             logger.error(f"Error deactivating policy rule: {err}")

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -217,7 +217,8 @@ async def delete_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
     try:
         okta_client = await get_okta_client(manager)
-        _, _, err = await okta_client.delete_policy(policy_id)
+        result = await okta_client.delete_policy(policy_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error deleting policy {policy_id}: {err}")
@@ -245,7 +246,8 @@ async def activate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
     okta_client = await get_okta_client(manager)
 
     try:
-        _, _, err = await okta_client.activate_policy(policy_id)
+        result = await okta_client.activate_policy(policy_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error activating policy {policy_id}: {err}")
@@ -288,7 +290,8 @@ async def deactivate_policy(ctx: Context, policy_id: str) -> Dict[str, Any]:
 
     try:
         okta_client = await get_okta_client(manager)
-        _, _, err = await okta_client.deactivate_policy(policy_id)
+        result = await okta_client.deactivate_policy(policy_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error deactivating policy {policy_id}: {err}")
@@ -468,7 +471,8 @@ async def delete_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Dict
 
     try:
         okta_client = await get_okta_client(manager)
-        _, _, err = await okta_client.delete_policy_rule(policy_id, rule_id)
+        result = await okta_client.delete_policy_rule(policy_id, rule_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error deleting policy rule: {err}")
@@ -497,7 +501,8 @@ async def activate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> Di
     okta_client = await get_okta_client(manager)
 
     try:
-        _, _, err = await okta_client.activate_policy_rule(policy_id, rule_id)
+        result = await okta_client.activate_policy_rule(policy_id, rule_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error activating policy rule: {err}")
@@ -539,7 +544,8 @@ async def deactivate_policy_rule(ctx: Context, policy_id: str, rule_id: str) -> 
 
     try:
         okta_client = await get_okta_client(manager)
-        _, _, err = await okta_client.deactivate_policy_rule(policy_id, rule_id)
+        result = await okta_client.deactivate_policy_rule(policy_id, rule_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Error deactivating policy rule: {err}")

--- a/src/okta_mcp_server/tools/policies/policies.py
+++ b/src/okta_mcp_server/tools/policies/policies.py
@@ -66,15 +66,13 @@ async def list_policies(
 
     try:
         okta_client = await get_okta_client(manager)
-        params = {"type": type, "limit": limit}
+        params = {"type": type, "limit": str(limit)}
         if status:
             params["status"] = status
         if q:
             params["q"] = q
         if after:
             params["after"] = after
-        if "limit" in params and params["limit"] is not None:
-            params["limit"] = str(params["limit"])
 
         logger.debug("Calling Okta API to list policies")
         policies, _, err = await okta_client.list_policies(**params)

--- a/src/okta_mcp_server/tools/system_logs/system_logs.py
+++ b/src/okta_mcp_server/tools/system_logs/system_logs.py
@@ -75,7 +75,7 @@ async def get_logs(
 
         query_params = build_query_params(after=after, limit=limit, since=since, until=until, filter=filter, q=q)
 
-        logs, response, err = await client.get_logs(query_params)
+        logs, response, err = await client.list_log_events(**query_params)
 
         if err:
             logger.error(f"Okta API error while retrieving system logs: {err}")

--- a/src/okta_mcp_server/tools/system_logs/system_logs.py
+++ b/src/okta_mcp_server/tools/system_logs/system_logs.py
@@ -12,7 +12,7 @@ from mcp.server.fastmcp import Context
 
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
-from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, extract_after_cursor, paginate_all_results
 
 
 @mcp.tool()
@@ -92,9 +92,13 @@ async def get_logs(
             logger.debug(f"First log entry timestamp: {logs[0].published if hasattr(logs[0], 'published') else 'N/A'}")
             logger.debug(f"Log types found: {set(log.eventType for log in logs[:10] if hasattr(log, 'eventType'))}")
 
-        if fetch_all and response and hasattr(response, "has_next") and response.has_next():
+        if fetch_all and response and extract_after_cursor(response):
             logger.info(f"fetch_all=True, auto-paginating from initial {log_count} log entries")
-            all_logs, pagination_info = await paginate_all_results(response, logs)
+            all_logs, pagination_info = await paginate_all_results(
+                response,
+                logs,
+                fetch_page_fn=lambda after: client.list_log_events(**{**query_params, "after": after}),
+            )
 
             logger.info(
                 f"Successfully retrieved {len(all_logs)} log entries across {pagination_info['pages_fetched']} pages"

--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -299,7 +299,8 @@ async def deactivate_user(user_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to deactivate user {user_id}")
 
-        _, _, err = await client.deactivate_user(user_id)
+        result = await client.deactivate_user(user_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deactivating user {user_id}: {err}")
@@ -345,7 +346,8 @@ async def delete_deactivated_user(user_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete user {user_id}")
 
-        _, _, err = await client.delete_user(user_id)
+        result = await client.delete_user(user_id)
+        err = result[-1]
 
         if err:
             logger.error(f"Okta API error while deleting user {user_id}: {err}")

--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -10,6 +10,9 @@ from typing import Optional
 from loguru import logger
 from mcp.server.fastmcp import Context
 
+from okta.models.create_user_request import CreateUserRequest
+from okta.models.update_user_request import UpdateUserRequest
+
 from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeactivateConfirmation, DeleteConfirmation, elicit_or_fallback
@@ -83,7 +86,7 @@ async def list_users(
         query_params = build_query_params(search=search, filter=filter, q=q, after=after, limit=limit)
 
         logger.debug("Calling Okta API to list users")
-        users, response, err = await client.list_users(query_params)
+        users, response, err = await client.list_users(**query_params)
 
         if err:
             logger.error(f"Okta API error while listing users: {err}")
@@ -134,7 +137,7 @@ async def get_user_profile_attributes(ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug("Fetching first user to extract profile attributes")
 
-        users, _, err = await client.list_users({"limit": 1})
+        users, _, err = await client.list_users(limit=1)
 
         if err:
             logger.error(f"Okta API error while fetching profile attributes: {err}")
@@ -174,7 +177,11 @@ async def get_user(user_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to get user {user_id}")
 
-        user = await client.get_user(user_id)
+        user, _, err = await client.get_user(user_id)
+
+        if err:
+            logger.error(f"Okta API error while getting user {user_id}: {err}")
+            return [f"Error: {err}"]
 
         logger.info(f"Successfully retrieved user: {user.profile.email if hasattr(user, 'profile') else user_id}")
         return [user]
@@ -202,8 +209,8 @@ async def create_user(profile: dict, ctx: Context = None) -> list:
 
     try:
         client = await get_okta_client(manager)
-        # Wrap the profile in a dict with 'profile' key as required by Okta SDK
-        user_data = {"profile": profile}
+        # Wrap the profile in a CreateUserRequest model as required by Okta SDK v3
+        user_data = CreateUserRequest.from_dict({"profile": profile})
         logger.debug("Calling Okta API to create user")
 
         user, _, err = await client.create_user(user_data)
@@ -241,7 +248,8 @@ async def update_user(user_id: str, profile: dict, ctx: Context = None) -> list:
 
     try:
         client = await get_okta_client(manager)
-        user_data = {"profile": profile}
+        # Wrap the profile in an UpdateUserRequest model as required by Okta SDK v3
+        user_data = UpdateUserRequest.from_dict({"profile": profile})
         logger.debug(f"Calling Okta API to update user {user_id}")
 
         user, _, err = await client.update_user(user_id, user_data)
@@ -291,7 +299,7 @@ async def deactivate_user(user_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to deactivate user {user_id}")
 
-        _, err = await client.deactivate_user(user_id)
+        _, _, err = await client.deactivate_user(user_id)
 
         if err:
             logger.error(f"Okta API error while deactivating user {user_id}: {err}")
@@ -337,7 +345,7 @@ async def delete_deactivated_user(user_id: str, ctx: Context = None) -> list:
         client = await get_okta_client(manager)
         logger.debug(f"Calling Okta API to delete user {user_id}")
 
-        _, err = await client.deactivate_or_delete_user(user_id)
+        _, _, err = await client.delete_user(user_id)
 
         if err:
             logger.error(f"Okta API error while deleting user {user_id}: {err}")

--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -17,7 +17,7 @@ from okta_mcp_server.server import mcp
 from okta_mcp_server.utils.client import get_okta_client
 from okta_mcp_server.utils.elicitation import DeactivateConfirmation, DeleteConfirmation, elicit_or_fallback
 from okta_mcp_server.utils.messages import DEACTIVATE_USER, DELETE_USER
-from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, paginate_all_results
+from okta_mcp_server.utils.pagination import build_query_params, create_paginated_response, extract_after_cursor, paginate_all_results
 from okta_mcp_server.utils.validation import validate_ids
 
 
@@ -99,9 +99,13 @@ async def list_users(
         # Convert users to the expected format
         user_items = [(user.profile, user.id) for user in users]
 
-        if fetch_all and response and hasattr(response, "has_next") and response.has_next():
+        if fetch_all and response and extract_after_cursor(response):
             logger.info(f"fetch_all=True, auto-paginating from initial {len(users)} users")
-            all_users, pagination_info = await paginate_all_results(response, users)
+            all_users, pagination_info = await paginate_all_results(
+                response,
+                users,
+                fetch_page_fn=lambda after: client.list_users(**{**query_params, "after": after}),
+            )
             all_user_items = [(user.profile, user.id) for user in all_users]
 
             logger.info(

--- a/src/okta_mcp_server/utils/messages.py
+++ b/src/okta_mcp_server/utils/messages.py
@@ -73,3 +73,12 @@ DEACTIVATE_POLICY_RULE = (
     "Are you sure you want to deactivate rule {rule_id} "
     "in policy {policy_id}?"
 )
+
+# ---------------------------------------------------------------------------
+# Device Assurance
+# ---------------------------------------------------------------------------
+
+DELETE_DEVICE_ASSURANCE_POLICY = (
+    "Are you sure you want to delete device assurance policy {policy_id}? "
+    "This action cannot be undone."
+)

--- a/src/okta_mcp_server/utils/pagination.py
+++ b/src/okta_mcp_server/utils/pagination.py
@@ -15,12 +15,42 @@ from loguru import logger
 def extract_after_cursor(response) -> Optional[str]:
     """Extract the 'after' cursor from the next page URL in Okta API response.
 
+    Supports both Okta SDK v2 (OktaAPIResponse with has_next/_next) and
+    v3 (ApiResponse with headers containing a Link header).
+
     Args:
-        response: OktaAPIResponse object
+        response: OktaAPIResponse (v2) or ApiResponse (v3) object
 
     Returns:
         str: The 'after' cursor value, or None if no next page
     """
+    import re
+
+    # --- Okta SDK v3: ApiResponse with Link header ---
+    if response and hasattr(response, "headers") and response.headers:
+        link_header = ""
+        try:
+            link_header = response.headers.get("Link", "") or response.headers.get("link", "")
+        except Exception:
+            for key in response.headers:
+                if key.lower() == "link":
+                    link_header = response.headers[key]
+                    break
+
+        if link_header and 'rel="next"' in link_header:
+            match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+            if match:
+                next_url = match.group(1)
+                try:
+                    parsed = urlparse(next_url)
+                    qp = parse_qs(parsed.query)
+                    cursor = qp.get("after", [None])[0]
+                    if cursor:
+                        return cursor
+                except Exception as e:
+                    logger.warning(f"Failed to parse Link header cursor: {e}")
+
+    # --- Okta SDK v2: OktaAPIResponse with has_next()/_next ---
     if not response or not hasattr(response, "has_next") or not response.has_next():
         return None
 
@@ -28,8 +58,8 @@ def extract_after_cursor(response) -> Optional[str]:
         # response._next contains URL like: "/api/v1/users?after=00u1abc123def456"
         if hasattr(response, "_next") and response._next:
             parsed = urlparse(response._next)
-            query_params = parse_qs(parsed.query)
-            return query_params.get("after", [None])[0]
+            qp = parse_qs(parsed.query)
+            return qp.get("after", [None])[0]
     except Exception as e:
         logger.warning(f"Failed to extract after cursor: {e}")
 
@@ -128,8 +158,10 @@ def create_paginated_response(
 
     # Add pagination info if not fetch_all
     if not fetch_all_used and response:
-        result["has_more"] = response.has_next() if hasattr(response, "has_next") else False
-        result["next_cursor"] = extract_after_cursor(response)
+        next_cursor = extract_after_cursor(response)
+        has_more_v2 = response.has_next() if hasattr(response, "has_next") else False
+        result["has_more"] = has_more_v2 or bool(next_cursor)
+        result["next_cursor"] = next_cursor
 
     # Add detailed pagination info if available
     if pagination_info:
@@ -170,11 +202,11 @@ def build_query_params(
     if after:
         query_params["after"] = after
     if limit:
-        query_params["limit"] = str(limit)
+        query_params["limit"] = limit
 
     # Add any additional parameters
     for key, value in kwargs.items():
         if value is not None and value != "":
-            query_params[key] = str(value)
+            query_params[key] = value
 
     return query_params

--- a/src/okta_mcp_server/utils/pagination.py
+++ b/src/okta_mcp_server/utils/pagination.py
@@ -6,6 +6,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 import asyncio
+import re
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qs, urlparse
 
@@ -24,8 +25,6 @@ def extract_after_cursor(response) -> Optional[str]:
     Returns:
         str: The 'after' cursor value, or None if no next page
     """
-    import re
-
     # --- Okta SDK v3: ApiResponse with Link header ---
     if response and hasattr(response, "headers") and response.headers:
         link_header = ""

--- a/src/okta_mcp_server/utils/pagination.py
+++ b/src/okta_mcp_server/utils/pagination.py
@@ -66,15 +66,26 @@ def extract_after_cursor(response) -> Optional[str]:
 
 
 async def paginate_all_results(
-    initial_response, initial_items: List, max_pages: int = 50, delay_between_requests: float = 0.1
+    initial_response,
+    initial_items: List,
+    max_pages: int = 50,
+    delay_between_requests: float = 0.1,
+    fetch_page_fn=None,
 ) -> Tuple[List, Dict[str, Any]]:
     """Auto-paginate through all pages of results.
 
+    Supports both Okta SDK v2 (OktaAPIResponse with has_next/next) and
+    v3 (ApiResponse with Link headers).
+
     Args:
-        initial_response: The first OktaAPIResponse object
+        initial_response: The first API response object (OktaAPIResponse v2 or ApiResponse v3)
         initial_items: The first page of items
         max_pages: Maximum number of pages to fetch (safety limit)
         delay_between_requests: Delay in seconds between requests
+        fetch_page_fn: Optional async callable used for SDK v3 pagination.
+            Signature: ``async (after: str) -> (items, response, err)``.
+            When provided, the v3 Link-header path is used; otherwise the
+            function falls back to the SDK v2 ``has_next()`` / ``next()`` path.
 
     Returns:
         Tuple of (all_items, pagination_info)
@@ -85,6 +96,54 @@ async def paginate_all_results(
 
     pagination_info = {"pages_fetched": 1, "total_items": len(all_items), "stopped_early": False, "stop_reason": None}
 
+    # --- Okta SDK v3 path: ApiResponse with Link header ---
+    if fetch_page_fn is not None:
+        try:
+            while pages_fetched < max_pages:
+                cursor = extract_after_cursor(response)
+                if not cursor:
+                    break
+
+                if delay_between_requests > 0:
+                    await asyncio.sleep(delay_between_requests)
+
+                try:
+                    next_items, response, next_err = await fetch_page_fn(cursor)
+
+                    if next_err:
+                        logger.warning(f"Error fetching page {pages_fetched + 1}: {next_err}")
+                        pagination_info["stopped_early"] = True
+                        pagination_info["stop_reason"] = f"API error: {next_err}"
+                        break
+
+                    if not next_items:
+                        break
+
+                    all_items.extend(next_items)
+                    pages_fetched += 1
+                    logger.debug(f"Fetched page {pages_fetched}, total items: {len(all_items)}")
+
+                except Exception as e:
+                    logger.error(f"Exception during pagination on page {pages_fetched + 1}: {e}")
+                    pagination_info["stopped_early"] = True
+                    pagination_info["stop_reason"] = f"Exception: {e}"
+                    break
+
+            if pages_fetched >= max_pages and extract_after_cursor(response):
+                pagination_info["stopped_early"] = True
+                pagination_info["stop_reason"] = f"Reached maximum page limit ({max_pages})"
+                logger.warning(f"Stopped pagination at {max_pages} pages limit")
+
+        except Exception as e:
+            logger.error(f"Unexpected error during pagination: {e}")
+            pagination_info["stopped_early"] = True
+            pagination_info["stop_reason"] = f"Unexpected error: {e}"
+
+        pagination_info["pages_fetched"] = pages_fetched
+        pagination_info["total_items"] = len(all_items)
+        return all_items, pagination_info
+
+    # --- Okta SDK v2 path: OktaAPIResponse with has_next()/next() ---
     if not response or not hasattr(response, "has_next"):
         return all_items, pagination_info
 

--- a/src/okta_mcp_server/utils/validation.py
+++ b/src/okta_mcp_server/utils/validation.py
@@ -16,7 +16,7 @@ URL paths when passed to the Okta SDK client.
 import functools
 import inspect
 import re
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from loguru import logger
 
@@ -187,6 +187,169 @@ def validate_ids(*id_params: str, error_return_type: str = "list"):
             return func(*args, **kwargs)
 
         # Return appropriate wrapper based on whether function is async
+        if inspect.iscoroutinefunction(func):
+            return async_wrapper
+        return sync_wrapper
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# OS version validation
+# ---------------------------------------------------------------------------
+
+# Matches exactly three or four numeric components (X.Y.Z or X.Y.Z.W).
+# Deliberately excludes two-component (X.Y) so we can give a tailored error.
+_OS_SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+(\.\d+)?$")
+
+# Matches two-component versions (X.Y) — incomplete without a patch number.
+_OS_TWO_COMPONENT_VERSION = re.compile(r"^\d+\.\d+$")
+
+# Matches single-component versions (X) — only valid for Android major versions.
+_OS_SINGLE_COMPONENT_VERSION = re.compile(r"^\d+$")
+
+
+def _validate_os_version_string(version: str, platform: str = "") -> Optional[str]:
+    """Validate a raw OS version string.
+
+    Accepts:
+        - X.Y.Z   (e.g. "14.2.1")
+        - X.Y.Z.W (e.g. "14.2.1.0")
+        - Single major version for ANDROID only (e.g. "12")
+
+    Rejects:
+        - Empty string        → None (nothing to validate)
+        - Two-component X.Y   → error listing multiple possible patch versions
+        - Single-component X  → error for non-Android platforms
+        - Anything else       → generic format error
+
+    Returns:
+        An error string if the version is invalid, ``None`` if it is valid.
+    """
+    if not version:
+        return None
+
+    platform_upper = (platform or "").upper()
+
+    # Single-component (e.g. "12"): only valid for Android.
+    if _OS_SINGLE_COMPONENT_VERSION.match(version):
+        if platform_upper == "ANDROID":
+            return None
+        return (
+            f"Invalid OS version format: '{version}'. "
+            f"Version must be in X.Y.Z or X.Y.Z.W format. "
+            f"For Android, a major version only (e.g. '12') is also accepted."
+        )
+
+    # Two-component (e.g. "14.2"): incomplete — the patch component is unknown.
+    # Do NOT suggest a specific completion: "13.3" and "13.3.0" are different versions.
+    if _OS_TWO_COMPONENT_VERSION.match(version):
+        return (
+            f"Incomplete OS version: '{version}'. "
+            f"This could mean '{version}.0', '{version}.1', or another patch release — "
+            f"they are NOT equivalent. "
+            f"You MUST ask the user which exact patch version they mean. "
+            f"Do NOT assume or guess '{version}.0'."
+        )
+
+    # Full semver check.
+    if not _OS_SEMVER_PATTERN.match(version):
+        return (
+            f"Invalid OS version format: '{version}'. "
+            f"Version must be in X.Y.Z or X.Y.Z.W format. "
+            f"For Android, a major version only (e.g. '12') is also accepted."
+        )
+
+    return None
+
+
+def validate_os_version_params(*param_names: str, error_return_type: str = "dict"):
+    """Decorator that validates OS version strings in tool parameters before execution.
+
+    Supports two parameter shapes:
+
+    1. **Direct string** (e.g. ``version_threshold="14.2"``):
+       The string is validated directly as an OS version.  The ``platform``
+       argument from the same call is used if present.
+
+    2. **Policy-data dict** (e.g. ``policy_data={"platform": "MACOS",
+       "osVersion": {"minimum": "14.2"}}``):
+       The version is extracted from ``param["osVersion"]["minimum"]`` or
+       ``param["os_version"]["minimum"]``, and the platform from
+       ``param["platform"]``.
+
+    If a two-component version such as ``"14.2"`` is detected, the tool call
+    is rejected **before it runs** and the error includes a
+    ``"Did you mean '14.2.0'?"`` hint so the LLM can ask the user for
+    clarification.
+
+    Args:
+        *param_names:       Names of function parameters to inspect.
+        error_return_type:  ``"dict"`` (default) or ``"list"`` — format of the
+                            error return value, matching ``validate_ids`` convention.
+
+    Usage::
+
+        @validate_os_version_params("version_threshold")
+        async def list_device_assurance_policies(ctx, version_threshold=None): ...
+
+        @validate_os_version_params("policy_data")
+        async def create_device_assurance_policy(ctx, policy_data): ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        def _check_arguments(bound_args) -> Optional[str]:
+            """Return an error string if any validated parameter contains a bad version."""
+            for param_name in param_names:
+                if param_name not in bound_args.arguments:
+                    continue
+                value = bound_args.arguments[param_name]
+                if value is None:
+                    continue
+
+                if isinstance(value, str):
+                    # Direct version string parameter (e.g. version_threshold).
+                    platform = bound_args.arguments.get("platform") or ""
+                    error = _validate_os_version_string(value, platform)
+                    if error:
+                        return error
+
+                elif isinstance(value, dict):
+                    # Policy-data dict with nested osVersion.
+                    os_version = value.get("osVersion") or value.get("os_version")
+                    if os_version and isinstance(os_version, dict):
+                        minimum = os_version.get("minimum")
+                        if minimum and isinstance(minimum, str):
+                            platform = value.get("platform") or ""
+                            error = _validate_os_version_string(minimum, platform)
+                            if error:
+                                return error
+            return None
+
+        @functools.wraps(func)
+        async def async_wrapper(*args, **kwargs) -> Any:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            error = _check_arguments(bound)
+            if error:
+                if error_return_type == "dict":
+                    return {"error": error}
+                return [f"Error: {error}"]
+            return await func(*args, **kwargs)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args, **kwargs) -> Any:
+            sig = inspect.signature(func)
+            bound = sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            error = _check_arguments(bound)
+            if error:
+                if error_return_type == "dict":
+                    return {"error": error}
+                return [f"Error: {error}"]
+            return func(*args, **kwargs)
+
         if inspect.iscoroutinefunction(func):
             return async_wrapper
         return sync_wrapper

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,7 +195,7 @@ def mock_okta_client():
     client.delete_policy.return_value = (None, None)
     client.delete_policy_rule.return_value = (None, None)
     client.deactivate_user.return_value = (None, None)
-    client.deactivate_or_delete_user.return_value = (None, None)
+    client.delete_user.return_value = (None, None)
     client.deactivate_application.return_value = (None, None)
     client.deactivate_policy.return_value = (None, None)
     client.deactivate_policy_rule.return_value = (None, None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,6 +189,7 @@ def mock_okta_client():
     """Return a ``MagicMock`` with async Okta client methods pre-configured."""
     client = AsyncMock()
     # Defaults: success, no error
+    client.delete_device_assurance_policy.return_value = (None, None)
     client.delete_group.return_value = (None, None)
     client.delete_application.return_value = (None, None)
     client.delete_policy.return_value = (None, None)

--- a/tests/elicitation/test_device_assurance_elicitation.py
+++ b/tests/elicitation/test_device_assurance_elicitation.py
@@ -1,0 +1,124 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for device assurance policy deletion with elicitation support."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from okta_mcp_server.tools.device_assurance.device_assurance import delete_device_assurance_policy
+
+
+DEVICE_ASSURANCE_ID = "da01234567890ABCDE"
+
+
+# ===================================================================
+# delete_device_assurance_policy — elicitation flows
+# ===================================================================
+
+class TestDeleteDeviceAssurancePolicyElicitation:
+    """Tests for delete_device_assurance_policy when the client supports elicitation."""
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_accept_confirmed_deletes(self, mock_get_client, ctx_elicit_accept_true, mock_okta_client):
+        mock_get_client.return_value = mock_okta_client
+
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_accept_true, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        mock_okta_client.delete_device_assurance_policy.assert_awaited_once_with(DEVICE_ASSURANCE_ID)
+        assert result["success"] is True
+        assert DEVICE_ASSURANCE_ID in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_accept_not_confirmed_cancels(self, ctx_elicit_accept_false):
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_accept_false, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "cancelled" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_decline_cancels(self, ctx_elicit_decline):
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_decline, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "cancelled" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_cancel_cancels(self, ctx_elicit_cancel):
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_cancel, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "cancelled" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_okta_api_error(self, mock_get_client, ctx_elicit_accept_true):
+        client = AsyncMock()
+        client.delete_device_assurance_policy.return_value = (None, "API Error: policy not found")
+        mock_get_client.return_value = client
+
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_accept_true, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_exception_during_delete(self, mock_get_client, ctx_elicit_accept_true):
+        mock_get_client.side_effect = Exception("Connection refused")
+
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_accept_true, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "error" in result
+
+
+# ===================================================================
+# delete_device_assurance_policy — fallback flows
+# ===================================================================
+
+class TestDeleteDeviceAssurancePolicyFallback:
+    """Tests for delete_device_assurance_policy when the client does NOT support elicitation.
+
+    Pre-elicitation behaviour: the operation proceeds directly without
+    confirmation because there was never a separate confirm tool for device assurance policies.
+    """
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_fallback_proceeds_with_deletion(self, mock_get_client, ctx_no_elicitation, mock_okta_client):
+        mock_get_client.return_value = mock_okta_client
+
+        result = await delete_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        mock_okta_client.delete_device_assurance_policy.assert_awaited_once_with(DEVICE_ASSURANCE_ID)
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_exception_fallback_proceeds_with_deletion(self, mock_get_client, ctx_elicit_exception, mock_okta_client):
+        mock_get_client.return_value = mock_okta_client
+
+        result = await delete_device_assurance_policy(
+            ctx=ctx_elicit_exception, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        mock_okta_client.delete_device_assurance_policy.assert_awaited_once_with(DEVICE_ASSURANCE_ID)
+        assert result["success"] is True

--- a/tests/elicitation/test_users_elicitation.py
+++ b/tests/elicitation/test_users_elicitation.py
@@ -124,7 +124,7 @@ class TestDeleteDeactivatedUserElicitation:
 
         result = await delete_deactivated_user(user_id=USER_ID, ctx=ctx_elicit_accept_true)
 
-        mock_okta_client.deactivate_or_delete_user.assert_awaited_once_with(USER_ID)
+        mock_okta_client.delete_user.assert_awaited_once_with(USER_ID)
         assert "deleted successfully" in result[0]
 
     @pytest.mark.asyncio
@@ -149,7 +149,7 @@ class TestDeleteDeactivatedUserElicitation:
     @patch("okta_mcp_server.tools.users.users.get_okta_client")
     async def test_okta_api_error(self, mock_get_client, ctx_elicit_accept_true):
         client = AsyncMock()
-        client.deactivate_or_delete_user.return_value = (None, "API Error: user not found")
+        client.delete_user.return_value = (None, "API Error: user not found")
         mock_get_client.return_value = client
 
         result = await delete_deactivated_user(user_id=USER_ID, ctx=ctx_elicit_accept_true)
@@ -184,7 +184,7 @@ class TestDeleteDeactivatedUserFallback:
 
         result = await delete_deactivated_user(user_id=USER_ID, ctx=ctx_no_elicitation)
 
-        mock_okta_client.deactivate_or_delete_user.assert_awaited_once_with(USER_ID)
+        mock_okta_client.delete_user.assert_awaited_once_with(USER_ID)
         assert "deleted successfully" in result[0]
 
     @pytest.mark.asyncio
@@ -194,5 +194,5 @@ class TestDeleteDeactivatedUserFallback:
 
         result = await delete_deactivated_user(user_id=USER_ID, ctx=ctx_elicit_exception)
 
-        mock_okta_client.deactivate_or_delete_user.assert_awaited_once_with(USER_ID)
+        mock_okta_client.delete_user.assert_awaited_once_with(USER_ID)
         assert "deleted successfully" in result[0]

--- a/tests/test_device_assurance.py
+++ b/tests/test_device_assurance.py
@@ -1,0 +1,696 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Unit tests for device assurance policy tools and helper functions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from okta_mcp_server.tools.device_assurance.device_assurance import (
+    _compute_policy_diff,
+    _enrich_policy_with_attribute_status,
+    _get_implication,
+    _validate_os_version,
+    create_device_assurance_policy,
+    get_device_assurance_policy,
+    list_device_assurance_policies,
+    replace_device_assurance_policy,
+)
+
+
+DEVICE_ASSURANCE_ID = "da01234567890ABCDE"
+
+MACOS_POLICY_DICT = {
+    "id": DEVICE_ASSURANCE_ID,
+    "name": "MacOS Compliance",
+    "platform": "MACOS",
+    "osVersion": {"minimum": "14.0.0"},
+    "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]},
+    "screenLockType": {"include": ["BIOMETRIC"]},
+    "secureHardwarePresent": True,
+}
+
+IOS_POLICY_DICT = {
+    "id": DEVICE_ASSURANCE_ID,
+    "name": "iOS Compliance",
+    "platform": "IOS",
+    "osVersion": {"minimum": "17.0.0"},
+    "jailbreak": False,
+    "screenLockType": {"include": ["BIOMETRIC"]},
+}
+
+
+def _make_policy_model(policy_dict: dict) -> MagicMock:
+    """Return a mock Okta SDK model whose to_dict() returns a copy of policy_dict."""
+    mock = MagicMock()
+    mock.to_dict.return_value = policy_dict.copy()
+    return mock
+
+
+# ===========================================================================
+# _validate_os_version
+# ===========================================================================
+
+class TestValidateOsVersion:
+    """Tests for the _validate_os_version helper."""
+
+    def test_returns_none_when_no_os_version_key(self):
+        assert _validate_os_version({}) is None
+
+    def test_returns_none_when_os_version_is_none(self):
+        assert _validate_os_version({"osVersion": None}) is None
+
+    def test_returns_none_when_minimum_is_absent(self):
+        assert _validate_os_version({"osVersion": {}}) is None
+
+    def test_returns_none_when_minimum_is_empty_string(self):
+        assert _validate_os_version({"osVersion": {"minimum": ""}}) is None
+
+    def test_valid_xyz_passes(self):
+        assert _validate_os_version({"osVersion": {"minimum": "14.2.1"}}) is None
+
+    def test_valid_xyzw_passes(self):
+        assert _validate_os_version({"osVersion": {"minimum": "14.2.1.0"}}) is None
+
+    def test_valid_xy_normalises_in_place_to_xyz(self):
+        data = {"osVersion": {"minimum": "14.2"}}
+        assert _validate_os_version(data) is None
+        assert data["osVersion"]["minimum"] == "14.2.0"
+
+    def test_single_component_returns_error(self):
+        error = _validate_os_version({"osVersion": {"minimum": "14"}})
+        assert error is not None
+        assert "Invalid" in error
+        assert "14" in error
+
+    def test_alpha_component_returns_error(self):
+        error = _validate_os_version({"osVersion": {"minimum": "14.2.alpha"}})
+        assert error is not None
+
+    def test_version_with_leading_dot_returns_error(self):
+        error = _validate_os_version({"osVersion": {"minimum": ".14.2.1"}})
+        assert error is not None
+
+    def test_snake_case_os_version_key_accepted(self):
+        assert _validate_os_version({"os_version": {"minimum": "14.2.1"}}) is None
+
+    def test_snake_case_xy_normalises_in_place(self):
+        data = {"os_version": {"minimum": "17.0"}}
+        assert _validate_os_version(data) is None
+        assert data["os_version"]["minimum"] == "17.0.0"
+
+    def test_error_message_contains_valid_format_hint(self):
+        error = _validate_os_version({"osVersion": {"minimum": "abc"}})
+        assert error is not None
+        assert "X.Y" in error
+
+
+# ===========================================================================
+# _enrich_policy_with_attribute_status
+# ===========================================================================
+
+class TestEnrichPolicyWithAttributeStatus:
+    """Tests for the _enrich_policy_with_attribute_status helper."""
+
+    def test_macos_all_attributes_configured(self):
+        result = _enrich_policy_with_attribute_status(MACOS_POLICY_DICT.copy())
+        status = result["securityAttributeStatus"]
+        assert status["osVersion"] == "configured"
+        assert status["diskEncryptionType"] == "configured"
+        assert status["screenLockType"] == "configured"
+        assert status["secureHardwarePresent"] == "configured"
+
+    def test_macos_missing_attributes_are_not_configured(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy)
+        status = result["securityAttributeStatus"]
+        assert status["osVersion"] == "configured"
+        assert status["diskEncryptionType"] == "not_configured"
+        assert status["screenLockType"] == "not_configured"
+        assert status["secureHardwarePresent"] == "not_configured"
+
+    def test_macos_status_keys_match_expected_attributes(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert set(result["securityAttributeStatus"].keys()) == {
+            "osVersion", "diskEncryptionType", "screenLockType", "secureHardwarePresent"
+        }
+
+    def test_ios_all_attributes_configured(self):
+        result = _enrich_policy_with_attribute_status(IOS_POLICY_DICT.copy())
+        status = result["securityAttributeStatus"]
+        assert status["osVersion"] == "configured"
+        # jailbreak=False is still "configured" — the setting exists, it's just set to False
+        assert status["jailbreak"] == "configured"
+        assert status["screenLockType"] == "configured"
+
+    def test_ios_missing_attributes_are_not_configured(self):
+        policy = {"id": "x", "name": "test", "platform": "IOS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        status = result["securityAttributeStatus"]
+        assert status["osVersion"] == "not_configured"
+        assert status["jailbreak"] == "not_configured"
+        assert status["screenLockType"] == "not_configured"
+
+    def test_android_expected_attributes(self):
+        policy = {"id": "x", "name": "test", "platform": "ANDROID", "osVersion": {"minimum": "12.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy)
+        status = result["securityAttributeStatus"]
+        assert status["osVersion"] == "configured"
+        assert status["jailbreak"] == "not_configured"
+        assert status["screenLockType"] == "not_configured"
+        # ANDROID does not include diskEncryptionType or secureHardwarePresent
+        assert "diskEncryptionType" not in status
+        assert "secureHardwarePresent" not in status
+
+    def test_windows_expected_attributes(self):
+        policy = {"id": "x", "name": "test", "platform": "WINDOWS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert set(result["securityAttributeStatus"].keys()) == {
+            "osVersion", "diskEncryptionType", "screenLockType", "secureHardwarePresent"
+        }
+
+    def test_chromeos_only_os_version(self):
+        policy = {"id": "x", "name": "test", "platform": "CHROMEOS", "osVersion": {"minimum": "115.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy)
+        status = result["securityAttributeStatus"]
+        assert set(status.keys()) == {"osVersion"}
+        assert status["osVersion"] == "configured"
+
+    def test_no_platform_key_returns_policy_unchanged(self):
+        policy = {"id": "x", "name": "test"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert "securityAttributeStatus" not in result
+
+    def test_unknown_platform_adds_empty_status(self):
+        policy = {"id": "x", "name": "test", "platform": "UNKNOWN"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert result["securityAttributeStatus"] == {}
+
+    def test_original_dict_is_mutated_in_place(self):
+        """The helper mutates and returns the same dict object."""
+        policy = {"id": "x", "name": "test", "platform": "CHROMEOS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert result is policy
+
+
+# ===========================================================================
+# _compute_policy_diff
+# ===========================================================================
+
+class TestComputePolicyDiff:
+    """Tests for the _compute_policy_diff helper."""
+
+    def test_identical_policies_return_empty_list(self):
+        policy = {"name": "Test", "platform": "MACOS"}
+        assert _compute_policy_diff(policy, policy.copy()) == []
+
+    def test_name_change_is_detected(self):
+        before = {"name": "Old Name", "platform": "MACOS"}
+        after = {"name": "New Name", "platform": "MACOS"}
+        diff = _compute_policy_diff(before, after)
+        assert len(diff) == 1
+        change = diff[0]
+        assert change["attribute"] == "name"
+        assert change["before"] == "Old Name"
+        assert change["after"] == "New Name"
+        assert "implication" in change
+
+    def test_metadata_keys_are_excluded(self):
+        before = {"name": "Test", "id": "old", "createdBy": "admin", "_links": {}, "lastUpdate": "2024"}
+        after = {"name": "Test", "id": "new", "createdBy": "user", "_links": {"self": "x"}, "lastUpdate": "2025"}
+        diff = _compute_policy_diff(before, after)
+        assert diff == []
+
+    def test_security_attribute_status_is_excluded(self):
+        before = {"name": "Test", "securityAttributeStatus": {"osVersion": "configured"}}
+        after = {"name": "Test", "securityAttributeStatus": {"osVersion": "not_configured"}}
+        diff = _compute_policy_diff(before, after)
+        assert diff == []
+
+    def test_multiple_changes_sorted_alphabetically(self):
+        before = {"name": "Old", "osVersion": {"minimum": "14.0.0"}}
+        after = {"name": "New", "osVersion": {"minimum": "15.0.0"}}
+        diff = _compute_policy_diff(before, after)
+        assert len(diff) == 2
+        assert diff[0]["attribute"] == "name"
+        assert diff[1]["attribute"] == "osVersion"
+
+    def test_added_attribute_shows_none_before(self):
+        before = {"name": "Test", "platform": "MACOS"}
+        after = {"name": "Test", "platform": "MACOS", "secureHardwarePresent": True}
+        diff = _compute_policy_diff(before, after)
+        assert len(diff) == 1
+        assert diff[0]["attribute"] == "secureHardwarePresent"
+        assert diff[0]["before"] is None
+        assert diff[0]["after"] is True
+
+    def test_removed_attribute_shows_none_after(self):
+        before = {"name": "Test", "platform": "MACOS", "secureHardwarePresent": True}
+        after = {"name": "Test", "platform": "MACOS"}
+        diff = _compute_policy_diff(before, after)
+        assert len(diff) == 1
+        assert diff[0]["attribute"] == "secureHardwarePresent"
+        assert diff[0]["before"] is True
+        assert diff[0]["after"] is None
+
+    def test_each_change_contains_required_fields(self):
+        before = {"name": "Old"}
+        after = {"name": "New"}
+        diff = _compute_policy_diff(before, after)
+        assert len(diff) == 1
+        assert {"attribute", "before", "after", "implication"} == set(diff[0].keys())
+
+
+# ===========================================================================
+# _get_implication
+# ===========================================================================
+
+class TestGetImplication:
+    """Tests for the _get_implication helper."""
+
+    def test_os_version_mentions_requirement(self):
+        result = _get_implication("osVersion", {"minimum": "13.0.0"}, {"minimum": "14.0.0"})
+        assert "OS version" in result
+
+    def test_jailbreak_enabled_mentions_blocked(self):
+        result = _get_implication("jailbreak", False, True)
+        assert "blocked" in result.lower()
+
+    def test_jailbreak_disabled_mentions_no_longer(self):
+        result = _get_implication("jailbreak", True, False)
+        assert "no longer" in result.lower()
+
+    def test_disk_encryption_mentions_encryption(self):
+        result = _get_implication("diskEncryptionType", None, {"include": ["ALL_INTERNAL_VOLUMES"]})
+        assert "encryption" in result.lower()
+
+    def test_screen_lock_mentions_screen_lock(self):
+        result = _get_implication("screenLockType", None, {"include": ["BIOMETRIC"]})
+        assert "screen lock" in result.lower()
+
+    def test_secure_hardware_enabled_mentions_hardware(self):
+        result = _get_implication("secureHardwarePresent", False, True)
+        assert "hardware" in result.lower() or "secure" in result.lower()
+
+    def test_secure_hardware_disabled_mentions_no_longer(self):
+        result = _get_implication("secureHardwarePresent", True, False)
+        assert "no longer" in result.lower()
+
+    def test_name_change_mentions_name(self):
+        result = _get_implication("name", "Old", "New")
+        assert "name" in result.lower()
+
+    def test_platform_change_mentions_platform(self):
+        result = _get_implication("platform", "MACOS", "WINDOWS")
+        assert "platform" in result.lower()
+
+    def test_unknown_attribute_includes_attr_name_in_message(self):
+        result = _get_implication("someCustomField", "a", "b")
+        assert "someCustomField" in result
+
+
+# ===========================================================================
+# list_device_assurance_policies
+# ===========================================================================
+
+class TestListDeviceAssurancePolicies:
+    """Tests for the list_device_assurance_policies tool."""
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_enriched_list_of_policies(self, mock_get_client, ctx_no_elicitation):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = ([mock_policy], MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "policies" in result
+        assert len(result["policies"]) == 1
+        assert "securityAttributeStatus" in result["policies"][0]
+        assert result["policies"][0]["platform"] == "MACOS"
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_multiple_policies(self, mock_get_client, ctx_no_elicitation):
+        mock_policies = [
+            _make_policy_model(MACOS_POLICY_DICT),
+            _make_policy_model(IOS_POLICY_DICT),
+        ]
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = (mock_policies, MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert len(result["policies"]) == 2
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_empty_list_when_no_policies(self, mock_get_client, ctx_no_elicitation):
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = ([], MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert result == {"policies": []}
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_api_error(self, mock_get_client, ctx_no_elicitation):
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = (None, MagicMock(), "API Error: forbidden")
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_exception(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = Exception("Connection refused")
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+
+
+# ===========================================================================
+# get_device_assurance_policy
+# ===========================================================================
+
+class TestGetDeviceAssurancePolicy:
+    """Tests for the get_device_assurance_policy tool."""
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_enriched_policy(self, mock_get_client, ctx_no_elicitation):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (mock_policy, MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await get_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert result["id"] == DEVICE_ASSURANCE_ID
+        assert "securityAttributeStatus" in result
+        client.get_device_assurance_policy.assert_awaited_once_with(DEVICE_ASSURANCE_ID)
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_none_when_policy_not_found(self, mock_get_client, ctx_no_elicitation):
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (None, MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await get_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_api_error(self, mock_get_client, ctx_no_elicitation):
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (None, MagicMock(), "Not Found")
+        mock_get_client.return_value = client
+
+        result = await get_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_exception(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = Exception("Timeout")
+
+        result = await get_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_id_returns_error_without_api_call(self, ctx_no_elicitation):
+        result = await get_device_assurance_policy(
+            ctx=ctx_no_elicitation, device_assurance_id="../evil/path"
+        )
+
+        assert "error" in result
+
+
+# ===========================================================================
+# create_device_assurance_policy
+# ===========================================================================
+
+class TestCreateDeviceAssurancePolicy:
+    """Tests for the create_device_assurance_policy tool."""
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_creates_policy_and_returns_dict(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.create_device_assurance_policy.return_value = (mock_policy, MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test MacOS Policy", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}},
+        )
+
+        assert result["id"] == DEVICE_ASSURANCE_ID
+        client.create_device_assurance_policy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_two_component_version_normalised_before_api_call(
+        self, mock_get_client, mock_da_cls, ctx_no_elicitation
+    ):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.create_device_assurance_policy.return_value = (mock_policy, MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        policy_data = {"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "14.2"}}
+        await create_device_assurance_policy(ctx=ctx_no_elicitation, policy_data=policy_data)
+
+        # Confirms normalisation mutated the dict before the model was built
+        assert policy_data["osVersion"]["minimum"] == "14.2.0"
+
+    @pytest.mark.asyncio
+    async def test_invalid_os_version_returns_error_before_api_call(self, ctx_no_elicitation):
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "14"}},
+        )
+
+        assert "error" in result
+        assert "Invalid" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_api_error(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        client = AsyncMock()
+        client.create_device_assurance_policy.return_value = (None, MagicMock(), "Validation Error")
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_exception(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = Exception("Connection error")
+
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_none_when_api_returns_no_policy(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        client = AsyncMock()
+        client.create_device_assurance_policy.return_value = (None, MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert result is None
+
+
+# ===========================================================================
+# replace_device_assurance_policy
+# ===========================================================================
+
+class TestReplaceDeviceAssurancePolicy:
+    """Tests for the replace_device_assurance_policy tool."""
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_before_after_and_changes(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        before_dict = {**MACOS_POLICY_DICT, "name": "Old Name"}
+        after_dict = {**MACOS_POLICY_DICT, "name": "New Name"}
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (_make_policy_model(before_dict), MagicMock(), None)
+        client.replace_device_assurance_policy.return_value = (_make_policy_model(after_dict), MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "New Name", "platform": "MACOS"},
+        )
+
+        assert "before" in result
+        assert "after" in result
+        assert "changes" in result
+        assert result["before"]["name"] == "Old Name"
+        assert result["after"]["name"] == "New Name"
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_changes_list_includes_name_change(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        before_dict = {**MACOS_POLICY_DICT, "name": "Old Name"}
+        after_dict = {**MACOS_POLICY_DICT, "name": "New Name"}
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (_make_policy_model(before_dict), MagicMock(), None)
+        client.replace_device_assurance_policy.return_value = (_make_policy_model(after_dict), MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "New Name", "platform": "MACOS"},
+        )
+
+        name_changes = [c for c in result["changes"] if c["attribute"] == "name"]
+        assert len(name_changes) == 1
+        assert name_changes[0]["before"] == "Old Name"
+        assert name_changes[0]["after"] == "New Name"
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_before_after_both_contain_security_attribute_status(
+        self, mock_get_client, mock_da_cls, ctx_no_elicitation
+    ):
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (_make_policy_model(MACOS_POLICY_DICT), MagicMock(), None)
+        client.replace_device_assurance_policy.return_value = (_make_policy_model(MACOS_POLICY_DICT), MagicMock(), None)
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "MacOS Compliance", "platform": "MACOS"},
+        )
+
+        assert "securityAttributeStatus" in result["before"]
+        assert "securityAttributeStatus" in result["after"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_when_fetch_fails(self, mock_get_client, ctx_no_elicitation):
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (None, MagicMock(), "Not Found")
+        mock_get_client.return_value = client
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+        client.replace_device_assurance_policy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_when_replace_api_fails(self, mock_get_client, mock_da_cls, ctx_no_elicitation):
+        client = AsyncMock()
+        client.get_device_assurance_policy.return_value = (_make_policy_model(MACOS_POLICY_DICT), MagicMock(), None)
+        client.replace_device_assurance_policy.return_value = (None, MagicMock(), "Conflict")
+        mock_get_client.return_value = client
+        mock_da_cls.from_dict.return_value = MagicMock()
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_os_version_returns_error_before_api_call(self, ctx_no_elicitation):
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "bad-version"}},
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_id_returns_error_without_api_call(self, ctx_no_elicitation):
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id="../../etc/passwd",
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_returns_error_dict_on_exception(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = Exception("Timeout")
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result

--- a/tests/test_device_assurance.py
+++ b/tests/test_device_assurance.py
@@ -20,6 +20,7 @@ from okta_mcp_server.tools.device_assurance.device_assurance import (
     _enrich_policy_with_attribute_status,
     _get_implication,
     _validate_os_version,
+    _validate_platform_attributes,
     create_device_assurance_policy,
     get_device_assurance_policy,
     list_device_assurance_policies,
@@ -136,11 +137,28 @@ class TestValidateOsVersion:
         assert _validate_os_version(data) is None
         assert data["osVersion"]["minimum"] == "14.2.0"
 
-    def test_single_component_returns_error(self):
+    def test_single_component_returns_error_without_platform(self):
+        # No platform key — Android special-case must NOT apply
         error = _validate_os_version({"osVersion": {"minimum": "14"}})
         assert error is not None
         assert "Invalid" in error
         assert "14" in error
+
+    def test_single_component_returns_error_for_non_android_platform(self):
+        error = _validate_os_version({"platform": "MACOS", "osVersion": {"minimum": "14"}})
+        assert error is not None
+        assert "Invalid" in error
+
+    def test_android_single_component_is_accepted_as_is(self):
+        data = {"platform": "ANDROID", "osVersion": {"minimum": "12"}}
+        assert _validate_os_version(data) is None
+        # Android major-only versions must not be normalised — Okta API expects "12", not "12.0.0"
+        assert data["osVersion"]["minimum"] == "12"
+
+    def test_android_single_component_zero_is_accepted_as_is(self):
+        data = {"platform": "ANDROID", "osVersion": {"minimum": "9"}}
+        assert _validate_os_version(data) is None
+        assert data["osVersion"]["minimum"] == "9"
 
     def test_alpha_component_returns_error(self):
         error = _validate_os_version({"osVersion": {"minimum": "14.2.alpha"}})
@@ -163,10 +181,122 @@ class TestValidateOsVersion:
         assert error is not None
         assert "X.Y" in error
 
+    def test_android_hint_in_error_message(self):
+        # The error message should hint that Android accepts single-component versions
+        error = _validate_os_version({"platform": "MACOS", "osVersion": {"minimum": "14"}})
+        assert error is not None
+        assert "Android" in error
+
 
 # ===========================================================================
-# _enrich_policy_with_attribute_status
+# _validate_platform_attributes
 # ===========================================================================
+
+class TestValidatePlatformAttributes:
+    """Tests for the _validate_platform_attributes helper."""
+
+    # --- Valid combinations should return None ---
+
+    def test_returns_none_when_no_platform(self):
+        assert _validate_platform_attributes({"diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]}}) is None
+
+    def test_returns_none_for_macos_with_valid_attributes(self):
+        data = {
+            "platform": "MACOS",
+            "osVersion": {"minimum": "14.0.0"},
+            "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]},
+            "screenLockType": {"include": ["BIOMETRIC"]},
+            "secureHardwarePresent": True,
+        }
+        assert _validate_platform_attributes(data) is None
+
+    def test_returns_none_for_android_with_jailbreak_false(self):
+        data = {"platform": "ANDROID", "jailbreak": False, "screenLockType": {"include": ["BIOMETRIC"]}}
+        assert _validate_platform_attributes(data) is None
+
+    def test_returns_none_for_ios_with_jailbreak_false(self):
+        data = {"platform": "IOS", "jailbreak": False}
+        assert _validate_platform_attributes(data) is None
+
+    def test_returns_none_for_chromeos_with_only_os_version(self):
+        assert _validate_platform_attributes({"platform": "CHROMEOS", "osVersion": {"minimum": "115.0.0"}}) is None
+
+    # --- Platform/attribute incompatibilities ---
+
+    def test_chromeos_with_disk_encryption_returns_error(self):
+        data = {"platform": "CHROMEOS", "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]}}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "diskEncryptionType" in error
+        assert "CHROMEOS" in error
+
+    def test_macos_with_jailbreak_returns_error(self):
+        data = {"platform": "MACOS", "jailbreak": False}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "jailbreak" in error
+        assert "MACOS" in error
+
+    def test_android_with_disk_encryption_returns_error(self):
+        data = {"platform": "ANDROID", "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]}}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "diskEncryptionType" in error
+
+    def test_ios_with_secure_hardware_returns_error(self):
+        data = {"platform": "IOS", "secureHardwarePresent": True}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "secureHardwarePresent" in error
+
+    def test_windows_with_jailbreak_returns_error(self):
+        data = {"platform": "WINDOWS", "jailbreak": False}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "jailbreak" in error
+
+    def test_error_message_includes_supported_platforms(self):
+        data = {"platform": "CHROMEOS", "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]}}
+        error = _validate_platform_attributes(data)
+        assert "MACOS" in error
+        assert "WINDOWS" in error
+
+    def test_error_message_includes_remove_hint(self):
+        data = {"platform": "IOS", "secureHardwarePresent": True}
+        error = _validate_platform_attributes(data)
+        assert "Remove" in error
+
+    # --- jailbreak=True validation ---
+
+    def test_jailbreak_true_on_android_returns_error(self):
+        data = {"platform": "ANDROID", "jailbreak": True}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "jailbreak" in error
+        assert "false" in error.lower()
+
+    def test_jailbreak_true_on_ios_returns_error(self):
+        data = {"platform": "IOS", "jailbreak": True}
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "jailbreak" in error
+        assert "false" in error.lower()
+
+    def test_jailbreak_false_on_android_is_valid(self):
+        # False is the only accepted value — must not be rejected
+        assert _validate_platform_attributes({"platform": "ANDROID", "jailbreak": False}) is None
+
+    def test_multiple_invalid_attributes_returns_combined_error(self):
+        data = {
+            "platform": "CHROMEOS",
+            "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]},
+            "secureHardwarePresent": True,
+        }
+        error = _validate_platform_attributes(data)
+        assert error is not None
+        assert "diskEncryptionType" in error
+        assert "secureHardwarePresent" in error
+
 
 class TestEnrichPolicyWithAttributeStatus:
     """Tests for the _enrich_policy_with_attribute_status helper."""

--- a/tests/test_device_assurance.py
+++ b/tests/test_device_assurance.py
@@ -390,6 +390,8 @@ class TestListDeviceAssurancePolicies:
         assert len(result["policies"]) == 1
         assert "securityAttributeStatus" in result["policies"][0]
         assert result["policies"][0]["platform"] == "MACOS"
+        assert "retrieved_at" in result
+        assert "note" in result
 
     @pytest.mark.asyncio
     @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
@@ -405,6 +407,8 @@ class TestListDeviceAssurancePolicies:
         result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
 
         assert len(result["policies"]) == 2
+        assert "retrieved_at" in result
+        assert "note" in result
 
     @pytest.mark.asyncio
     @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
@@ -415,7 +419,29 @@ class TestListDeviceAssurancePolicies:
 
         result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
 
-        assert result == {"policies": []}
+        assert result["policies"] == []
+        assert "retrieved_at" in result
+        assert "note" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_none_policies_transient_returns_warning_with_metadata(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        """When the SDK returns (None, 2xx_resp, None), the response must include
+        the transient-retry warning, retrieved_at, and note fields."""
+        client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        client.list_device_assurance_policies.return_value = (None, mock_resp, None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert result["policies"] == []
+        assert "warning" in result
+        assert "retrieved_at" in result
+        assert "note" in result
 
     @pytest.mark.asyncio
     @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")

--- a/tests/test_device_assurance.py
+++ b/tests/test_device_assurance.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from okta.exceptions.exceptions import ForbiddenException, UnauthorizedException
 
 from okta_mcp_server.tools.device_assurance.device_assurance import (
+    _build_scope_error,
     _compute_policy_diff,
     _enrich_policy_with_attribute_status,
     _get_implication,
@@ -52,6 +54,56 @@ def _make_policy_model(policy_dict: dict) -> MagicMock:
     mock = MagicMock()
     mock.to_dict.return_value = policy_dict.copy()
     return mock
+
+
+def _make_forbidden_exception(status: int = 403) -> ForbiddenException:
+    """Create a minimal ForbiddenException / UnauthorizedException for testing."""
+    exc = ForbiddenException.__new__(ForbiddenException)
+    exc.status = status
+    exc.reason = "Forbidden" if status == 403 else "Unauthorized"
+    exc.body = None
+    exc.data = None
+    exc.headers = None
+    return exc
+
+
+# ===========================================================================
+# _build_scope_error
+# ===========================================================================
+
+class TestBuildScopeError:
+    """Tests for the _build_scope_error helper."""
+
+    def test_read_operation_mentions_read_scope(self):
+        result = _build_scope_error("list")
+        assert "okta.deviceAssurance.read" in result["error"]
+
+    def test_write_operation_mentions_manage_scope(self):
+        for op in ("create", "replace", "delete"):
+            result = _build_scope_error(op)
+            assert "okta.deviceAssurance.manage" in result["error"], f"Failed for operation: {op}"
+
+    def test_status_code_is_included_in_message(self):
+        result = _build_scope_error("list", status=401)
+        assert "401" in result["error"]
+
+    def test_mentions_permissions_blocked(self):
+        result = _build_scope_error("list", status=403)
+        assert "blocked by permissions" in result["error"].lower()
+
+    def test_mentions_device_assurance(self):
+        result = _build_scope_error("list", status=403)
+        assert "device assurance" in result["error"].lower()
+
+    def test_mentions_mcp_config_scopes(self):
+        result = _build_scope_error("list", status=403)
+        assert "mcp.json" in result["error"].lower()
+        assert "okta_scopes" in result["error"].lower()
+
+    def test_returns_dict_with_error_key(self):
+        result = _build_scope_error("list")
+        assert "error" in result
+        assert isinstance(result["error"], str)
 
 
 # ===========================================================================
@@ -385,6 +437,88 @@ class TestListDeviceAssurancePolicies:
 
         assert "error" in result
 
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_forbidden_exception_returns_scope_error(self, mock_get_client, ctx_no_elicitation):
+        """A ForbiddenException (403 with JSON body) should surface a clear scope error."""
+        mock_get_client.side_effect = _make_forbidden_exception(403)
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "okta.deviceAssurance.read" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_unauthorised_exception_returns_scope_error(self, mock_get_client, ctx_no_elicitation):
+        """An UnauthorizedException (401) should also surface a clear scope error."""
+        exc = ForbiddenException.__new__(UnauthorizedException)
+        exc.status = 401
+        exc.reason = "Unauthorized"
+        exc.body = None
+        exc.data = None
+        exc.headers = None
+        mock_get_client.side_effect = exc
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+        assert "401" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_none_policies_with_403_response_returns_scope_error(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        """When the SDK returns (None, resp, None) with a 403 status (empty 403 body),
+        the tool must return a scope error rather than the transient-retry warning."""
+        client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        client.list_device_assurance_policies.return_value = (None, mock_resp, None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "okta.deviceAssurance.read" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_none_policies_with_401_response_returns_scope_error(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        client.list_device_assurance_policies.return_value = (None, mock_resp, None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+        assert "401" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_scope_precheck_short_circuits_without_api_call(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        """If the cached token clearly lacks okta.policies.read, the tool should return
+        the scope error immediately and not attempt any API call.
+        """
+        # Configure the fake auth manager to expose a scopes string
+        # that is missing okta.deviceAssurance.read.
+        ctx_no_elicitation.request_context.lifespan_context.okta_auth_manager.scopes = "okta.users.read"
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+
+        assert "error" in result
+        assert "okta.deviceAssurance.read" in result["error"]
+        mock_get_client.assert_not_called()
+
 
 # ===========================================================================
 # get_device_assurance_policy
@@ -447,12 +581,17 @@ class TestGetDeviceAssurancePolicy:
         assert "error" in result
 
     @pytest.mark.asyncio
-    async def test_invalid_id_returns_error_without_api_call(self, ctx_no_elicitation):
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_forbidden_exception_returns_scope_error(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = _make_forbidden_exception(403)
+
         result = await get_device_assurance_policy(
-            ctx=ctx_no_elicitation, device_assurance_id="../evil/path"
+            ctx=ctx_no_elicitation, device_assurance_id=DEVICE_ASSURANCE_ID
         )
 
         assert "error" in result
+        assert "403" in result["error"]
+        assert "okta.deviceAssurance.read" in result["error"]
 
 
 # ===========================================================================
@@ -535,6 +674,20 @@ class TestCreateDeviceAssurancePolicy:
         )
 
         assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_forbidden_exception_returns_scope_error(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = _make_forbidden_exception(403)
+
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "okta.deviceAssurance.manage" in result["error"]
 
     @pytest.mark.asyncio
     @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
@@ -694,3 +847,18 @@ class TestReplaceDeviceAssurancePolicy:
         )
 
         assert "error" in result
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_forbidden_exception_returns_scope_error(self, mock_get_client, ctx_no_elicitation):
+        mock_get_client.side_effect = _make_forbidden_exception(403)
+
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS"},
+        )
+
+        assert "error" in result
+        assert "403" in result["error"]
+        assert "okta.deviceAssurance.manage" in result["error"]

--- a/tests/test_device_assurance.py
+++ b/tests/test_device_assurance.py
@@ -17,9 +17,9 @@ from okta.exceptions.exceptions import ForbiddenException, UnauthorizedException
 from okta_mcp_server.tools.device_assurance.device_assurance import (
     _build_scope_error,
     _compute_policy_diff,
+    _detect_unverifiable_attributes,
     _enrich_policy_with_attribute_status,
     _get_implication,
-    _validate_os_version,
     _validate_platform_attributes,
     create_device_assurance_policy,
     get_device_assurance_policy,
@@ -69,6 +69,100 @@ def _make_forbidden_exception(status: int = 403) -> ForbiddenException:
 
 
 # ===========================================================================
+# Tool docstring contract tests (AC2 / AC3 guard rails)
+# ===========================================================================
+
+class TestToolDocstringContracts:
+    """Guard-rail tests that ensure critical LLM instruction text is present in
+    the tool docstrings / response bodies.  If these fail it means a refactor
+    accidentally removed text the LLM relies on to behave correctly."""
+
+    def test_list_tool_exposes_version_threshold_parameter(self):
+        """AC2: list_device_assurance_policies must declare a version_threshold
+        parameter so the validate_os_version_params decorator can intercept
+        incomplete versions before the tool body runs."""
+        import inspect
+        sig = inspect.signature(list_device_assurance_policies)
+        assert "version_threshold" in sig.parameters, (
+            "list_device_assurance_policies is missing the 'version_threshold' parameter "
+            "required for pre-call OS version validation"
+        )
+
+    def test_list_tool_version_threshold_defaults_to_none(self):
+        import inspect
+        sig = inspect.signature(list_device_assurance_policies)
+        default = sig.parameters["version_threshold"].default
+        assert default is None
+
+    def test_replace_docstring_mandatory_block_at_top(self):
+        """AC3: The MANDATORY RESPONSE FORMAT block must appear before the
+        'Platform-specific attribute support' section."""
+        doc = replace_device_assurance_policy.__doc__ or ""
+        mandatory_pos = doc.find("MANDATORY RESPONSE FORMAT")
+        platform_pos = doc.find("Platform-specific attribute support")
+        assert mandatory_pos != -1, "MANDATORY RESPONSE FORMAT block is missing from replace docstring"
+        assert mandatory_pos < platform_pos, (
+            "MANDATORY RESPONSE FORMAT block must come before the platform attributes section"
+        )
+
+    def test_replace_docstring_says_never_reply_done(self):
+        """AC3: The docstring must explicitly forbid a 'Done' response."""
+        doc = replace_device_assurance_policy.__doc__ or ""
+        assert "Done" in doc
+
+    # --- AC2: list tool must have the MANDATORY version-threshold block ---
+
+    def test_list_docstring_contains_mandatory_version_block(self):
+        """AC2: The list docstring must have a MANDATORY block calling out that
+        version_threshold MUST be passed — not filtered locally."""
+        doc = list_device_assurance_policies.__doc__ or ""
+        assert "MANDATORY" in doc, (
+            "list_device_assurance_policies docstring is missing the MANDATORY "
+            "version threshold block"
+        )
+
+    def test_list_docstring_prohibits_self_filtering(self):
+        """AC2: The docstring must explicitly tell the LLM never to filter locally."""
+        doc = list_device_assurance_policies.__doc__ or ""
+        assert "NEVER call this tool with no arguments" in doc, (
+            "list docstring must contain 'NEVER call this tool with no arguments' "
+            "to prevent the LLM from bypassing version_threshold validation"
+        )
+
+    def test_list_docstring_shows_wrong_and_right_call_examples(self):
+        """AC2: The docstring must include both a WRONG and RIGHT call example
+        so the LLM has a concrete pattern to follow."""
+        doc = list_device_assurance_policies.__doc__ or ""
+        assert "WRONG" in doc
+        assert "RIGHT" in doc
+
+    # --- AC2 / AC3: replace tool must forbid invented versions ---
+
+    def test_replace_docstring_says_never_invent_version(self):
+        """AC2/AC3: The replace docstring must tell the LLM never to complete or guess a version."""
+        doc = replace_device_assurance_policy.__doc__ or ""
+        assert "NEVER invent" in doc, (
+            "replace_device_assurance_policy docstring is missing the "
+            "'NEVER invent' instruction that prevents invented/normalized version numbers"
+        )
+        assert "NOT the same" in doc, (
+            "replace docstring must make clear that X.Y and X.Y.0 are different versions"
+        )
+        assert "user_stated_os_version" in doc, (
+            "replace docstring must mention user_stated_os_version as the required "
+            "channel for OS version changes"
+        )
+
+    def test_replace_docstring_instructs_to_ask_for_version(self):
+        """AC2: If the user hasn't confirmed an exact version, the LLM must ask."""
+        doc = replace_device_assurance_policy.__doc__ or ""
+        assert "STOP and ask" in doc, (
+            "replace docstring must tell the LLM to STOP and ask when no "
+            "explicit version has been confirmed"
+        )
+
+
+# ===========================================================================
 # _build_scope_error
 # ===========================================================================
 
@@ -105,87 +199,6 @@ class TestBuildScopeError:
         result = _build_scope_error("list")
         assert "error" in result
         assert isinstance(result["error"], str)
-
-
-# ===========================================================================
-# _validate_os_version
-# ===========================================================================
-
-class TestValidateOsVersion:
-    """Tests for the _validate_os_version helper."""
-
-    def test_returns_none_when_no_os_version_key(self):
-        assert _validate_os_version({}) is None
-
-    def test_returns_none_when_os_version_is_none(self):
-        assert _validate_os_version({"osVersion": None}) is None
-
-    def test_returns_none_when_minimum_is_absent(self):
-        assert _validate_os_version({"osVersion": {}}) is None
-
-    def test_returns_none_when_minimum_is_empty_string(self):
-        assert _validate_os_version({"osVersion": {"minimum": ""}}) is None
-
-    def test_valid_xyz_passes(self):
-        assert _validate_os_version({"osVersion": {"minimum": "14.2.1"}}) is None
-
-    def test_valid_xyzw_passes(self):
-        assert _validate_os_version({"osVersion": {"minimum": "14.2.1.0"}}) is None
-
-    def test_valid_xy_normalises_in_place_to_xyz(self):
-        data = {"osVersion": {"minimum": "14.2"}}
-        assert _validate_os_version(data) is None
-        assert data["osVersion"]["minimum"] == "14.2.0"
-
-    def test_single_component_returns_error_without_platform(self):
-        # No platform key — Android special-case must NOT apply
-        error = _validate_os_version({"osVersion": {"minimum": "14"}})
-        assert error is not None
-        assert "Invalid" in error
-        assert "14" in error
-
-    def test_single_component_returns_error_for_non_android_platform(self):
-        error = _validate_os_version({"platform": "MACOS", "osVersion": {"minimum": "14"}})
-        assert error is not None
-        assert "Invalid" in error
-
-    def test_android_single_component_is_accepted_as_is(self):
-        data = {"platform": "ANDROID", "osVersion": {"minimum": "12"}}
-        assert _validate_os_version(data) is None
-        # Android major-only versions must not be normalised — Okta API expects "12", not "12.0.0"
-        assert data["osVersion"]["minimum"] == "12"
-
-    def test_android_single_component_zero_is_accepted_as_is(self):
-        data = {"platform": "ANDROID", "osVersion": {"minimum": "9"}}
-        assert _validate_os_version(data) is None
-        assert data["osVersion"]["minimum"] == "9"
-
-    def test_alpha_component_returns_error(self):
-        error = _validate_os_version({"osVersion": {"minimum": "14.2.alpha"}})
-        assert error is not None
-
-    def test_version_with_leading_dot_returns_error(self):
-        error = _validate_os_version({"osVersion": {"minimum": ".14.2.1"}})
-        assert error is not None
-
-    def test_snake_case_os_version_key_accepted(self):
-        assert _validate_os_version({"os_version": {"minimum": "14.2.1"}}) is None
-
-    def test_snake_case_xy_normalises_in_place(self):
-        data = {"os_version": {"minimum": "17.0"}}
-        assert _validate_os_version(data) is None
-        assert data["os_version"]["minimum"] == "17.0.0"
-
-    def test_error_message_contains_valid_format_hint(self):
-        error = _validate_os_version({"osVersion": {"minimum": "abc"}})
-        assert error is not None
-        assert "X.Y" in error
-
-    def test_android_hint_in_error_message(self):
-        # The error message should hint that Android accepts single-component versions
-        error = _validate_os_version({"platform": "MACOS", "osVersion": {"minimum": "14"}})
-        assert error is not None
-        assert "Android" in error
 
 
 # ===========================================================================
@@ -382,12 +395,147 @@ class TestEnrichPolicyWithAttributeStatus:
         result = _enrich_policy_with_attribute_status(policy)
         assert result is policy
 
+    # --- AC1: Policy status field ---
+
+    def test_status_field_preserved_when_present(self):
+        policy = {**MACOS_POLICY_DICT.copy(), "status": "ACTIVE"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert result["status"] == "ACTIVE"
+
+    def test_inactive_status_is_preserved(self):
+        policy = {**MACOS_POLICY_DICT.copy(), "status": "INACTIVE"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert result["status"] == "INACTIVE"
+
+    def test_status_field_set_to_unknown_when_absent(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert result["status"] == "UNKNOWN"
+
+    def test_no_platform_key_does_not_add_status(self):
+        """When there is no platform, the function returns early without touching status."""
+        policy = {"id": "x", "name": "test"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert "status" not in result
+        assert "securityAttributeStatus" not in result
+
+    # --- AC4: Partial failure / unverifiable attributes ---
+
+    def test_unverifiable_attrs_marked_as_unverifiable(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs={"diskEncryptionType"})
+        assert result["securityAttributeStatus"]["diskEncryptionType"] == "unverifiable"
+
+    def test_unverifiable_attrs_do_not_affect_configured_attrs(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs={"diskEncryptionType"})
+        assert result["securityAttributeStatus"]["osVersion"] == "configured"
+
+    def test_non_unverifiable_absent_attrs_remain_not_configured(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs={"diskEncryptionType"})
+        assert result["securityAttributeStatus"]["screenLockType"] == "not_configured"
+
+    def test_partial_failure_section_added_when_unverifiable(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs={"diskEncryptionType"})
+        assert "partial_failure" in result
+        assert "diskEncryptionType" in result["partial_failure"]["unverifiable_attributes"]
+        assert "message" in result["partial_failure"]
+
+    def test_partial_failure_message_says_not_treat_as_not_configured(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs={"diskEncryptionType"})
+        assert "not configured" in result["partial_failure"]["message"].lower()
+
+    def test_no_partial_failure_section_when_no_unverifiable_attrs(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy)
+        assert "partial_failure" not in result
+
+    def test_empty_unverifiable_attrs_set_does_not_add_partial_failure(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(policy, unverifiable_attrs=set())
+        assert "partial_failure" not in result
+
+    def test_all_unverifiable_attrs_listed_in_partial_failure(self):
+        policy = {"id": "x", "name": "test", "platform": "MACOS"}
+        result = _enrich_policy_with_attribute_status(
+            policy, unverifiable_attrs={"diskEncryptionType", "screenLockType"}
+        )
+        listed = result["partial_failure"]["unverifiable_attributes"]
+        assert "diskEncryptionType" in listed
+        assert "screenLockType" in listed
+
 
 # ===========================================================================
 # _compute_policy_diff
 # ===========================================================================
 
-class TestComputePolicyDiff:
+class TestDetectUnverifiableAttributes:
+    """Tests for the _detect_unverifiable_attributes helper."""
+
+    def test_returns_empty_set_when_resp_is_none(self):
+        assert _detect_unverifiable_attributes({}, None) == set()
+
+    def test_returns_empty_set_for_200_response(self):
+        resp = MagicMock()
+        resp.status_code = 200
+        assert _detect_unverifiable_attributes({"platform": "MACOS"}, resp) == set()
+
+    def test_returns_empty_set_for_201_response(self):
+        resp = MagicMock()
+        resp.status_code = 201
+        assert _detect_unverifiable_attributes({"platform": "MACOS"}, resp) == set()
+
+    def test_returns_missing_attrs_for_207_response(self):
+        resp = MagicMock()
+        resp.status_code = 207
+        policy = {"platform": "MACOS", "osVersion": {"minimum": "14.0.0"}}
+        result = _detect_unverifiable_attributes(policy, resp)
+        assert "diskEncryptionType" in result
+        assert "screenLockType" in result
+        assert "secureHardwarePresent" in result
+        assert "osVersion" not in result  # present in the policy dict
+
+    def test_returns_empty_set_for_207_when_all_attrs_present(self):
+        resp = MagicMock()
+        resp.status_code = 207
+        policy = {
+            "platform": "MACOS",
+            "osVersion": {"minimum": "14.0.0"},
+            "diskEncryptionType": {"include": ["ALL_INTERNAL_VOLUMES"]},
+            "screenLockType": {"include": ["BIOMETRIC"]},
+            "secureHardwarePresent": True,
+        }
+        result = _detect_unverifiable_attributes(policy, resp)
+        assert result == set()
+
+    def test_unknown_platform_returns_empty_set_for_207(self):
+        resp = MagicMock()
+        resp.status_code = 207
+        result = _detect_unverifiable_attributes({"platform": "UNKNOWN"}, resp)
+        assert result == set()
+
+    def test_resp_without_status_code_returns_empty_set(self):
+        """When resp has neither status_code nor status, no partial failure is assumed."""
+        resp = object()  # bare object — no status attributes
+        result = _detect_unverifiable_attributes({"platform": "MACOS"}, resp)
+        assert result == set()
+
+    def test_ios_missing_attrs_for_207(self):
+        resp = MagicMock()
+        resp.status_code = 207
+        policy = {"platform": "IOS"}
+        result = _detect_unverifiable_attributes(policy, resp)
+        assert "jailbreak" in result
+        assert "screenLockType" in result
+        assert "osVersion" in result
+
+
+# ===========================================================================
+# _compute_policy_diff
+# ===========================================================================
     """Tests for the _compute_policy_diff helper."""
 
     def test_identical_policies_return_empty_list(self):
@@ -675,6 +823,70 @@ class TestListDeviceAssurancePolicies:
         assert "okta.deviceAssurance.read" in result["error"]
         mock_get_client.assert_not_called()
 
+    # --- AC2: version_threshold pre-validation ---
+
+    @pytest.mark.asyncio
+    async def test_two_component_version_threshold_rejected_before_api_call(
+        self, ctx_no_elicitation
+    ):
+        """AC2: passing version_threshold='14.2' must be rejected by the
+        validate_os_version_params decorator before the tool body runs."""
+        result = await list_device_assurance_policies(
+            ctx=ctx_no_elicitation, version_threshold="14.2"
+        )
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+        assert "14.2.0" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_threshold_error_warns_not_to_assume(
+        self, ctx_no_elicitation
+    ):
+        result = await list_device_assurance_policies(
+            ctx=ctx_no_elicitation, version_threshold="10.15"
+        )
+        assert "error" in result
+        assert "Do NOT assume" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_valid_three_component_threshold_passes_through(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = ([mock_policy], MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(
+            ctx=ctx_no_elicitation, version_threshold="14.2.1"
+        )
+        assert "error" not in result
+        assert result["version_threshold"] == "14.2.1"
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
+    async def test_none_version_threshold_omitted_from_response(
+        self, mock_get_client, ctx_no_elicitation
+    ):
+        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
+        client = AsyncMock()
+        client.list_device_assurance_policies.return_value = ([mock_policy], MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await list_device_assurance_policies(ctx=ctx_no_elicitation)
+        assert "error" not in result
+        assert "version_threshold" not in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_format_threshold_rejected(
+        self, ctx_no_elicitation
+    ):
+        result = await list_device_assurance_policies(
+            ctx=ctx_no_elicitation, version_threshold="notaversion"
+        )
+        assert "error" in result
+
 
 # ===========================================================================
 # get_device_assurance_policy
@@ -769,35 +981,34 @@ class TestCreateDeviceAssurancePolicy:
 
         result = await create_device_assurance_policy(
             ctx=ctx_no_elicitation,
-            policy_data={"name": "Test MacOS Policy", "platform": "MACOS", "osVersion": {"minimum": "14.0.0"}},
+            policy_data={"name": "Test MacOS Policy", "platform": "MACOS"},
+            user_stated_os_version="14.0.0",
         )
 
         assert result["id"] == DEVICE_ASSURANCE_ID
         client.create_device_assurance_policy.assert_awaited_once()
 
     @pytest.mark.asyncio
-    @patch("okta_mcp_server.tools.device_assurance.device_assurance.DeviceAssurance")
-    @patch("okta_mcp_server.tools.device_assurance.device_assurance.get_okta_client")
-    async def test_two_component_version_normalised_before_api_call(
-        self, mock_get_client, mock_da_cls, ctx_no_elicitation
+    async def test_two_component_version_rejected_before_api_call(
+        self, ctx_no_elicitation
     ):
-        mock_policy = _make_policy_model(MACOS_POLICY_DICT)
-        client = AsyncMock()
-        client.create_device_assurance_policy.return_value = (mock_policy, MagicMock(), None)
-        mock_get_client.return_value = client
-        mock_da_cls.from_dict.return_value = MagicMock()
+        # AC2: X.Y in user_stated_os_version must be rejected before the API is called.
+        result = await create_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            policy_data={"name": "Test", "platform": "MACOS"},
+            user_stated_os_version="14.2",
+        )
 
-        policy_data = {"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "14.2"}}
-        await create_device_assurance_policy(ctx=ctx_no_elicitation, policy_data=policy_data)
-
-        # Confirms normalisation mutated the dict before the model was built
-        assert policy_data["osVersion"]["minimum"] == "14.2.0"
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+        assert "14.2.0" in result["error"]
 
     @pytest.mark.asyncio
     async def test_invalid_os_version_returns_error_before_api_call(self, ctx_no_elicitation):
         result = await create_device_assurance_policy(
             ctx=ctx_no_elicitation,
-            policy_data={"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "14"}},
+            policy_data={"name": "Test", "platform": "MACOS"},
+            user_stated_os_version="14",
         )
 
         assert "error" in result
@@ -890,6 +1101,8 @@ class TestReplaceDeviceAssurancePolicy:
         assert "before" in result
         assert "after" in result
         assert "changes" in result
+        assert "_display_required" in result
+        assert result["_display_required"]  # must be a non-empty instruction string
         assert result["before"]["name"] == "Old Name"
         assert result["after"]["name"] == "New Name"
 
@@ -976,10 +1189,38 @@ class TestReplaceDeviceAssurancePolicy:
         result = await replace_device_assurance_policy(
             ctx=ctx_no_elicitation,
             device_assurance_id=DEVICE_ASSURANCE_ID,
-            policy_data={"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "bad-version"}},
+            policy_data={"name": "Test", "platform": "MACOS"},
+            user_stated_os_version="bad-version",
         )
 
         assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_os_version_in_policy_data_without_user_stated_rejected(
+        self, ctx_no_elicitation
+    ):
+        """AC2: If policy_data contains osVersion but user_stated_os_version is absent,
+        the tool must refuse — forcing the LLM to always use the verbatim channel."""
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS", "osVersion": {"minimum": "13.2.0"}},
+        )
+        assert "error" in result
+        assert "osVersion must NOT be included" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_xy_in_user_stated_os_version_rejected(self, ctx_no_elicitation):
+        """AC2: A two-component version in user_stated_os_version must be rejected
+        by the decorator before the tool body or API call runs."""
+        result = await replace_device_assurance_policy(
+            ctx=ctx_no_elicitation,
+            device_assurance_id=DEVICE_ASSURANCE_ID,
+            policy_data={"name": "Test", "platform": "MACOS"},
+            user_stated_os_version="13.2",
+        )
+        assert "error" in result
+        assert "Incomplete" in result["error"]
 
     @pytest.mark.asyncio
     async def test_invalid_id_returns_error_without_api_call(self, ctx_no_elicitation):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,721 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for pagination utilities and fetch_all=True branches in all four affected tools.
+
+Covers the Gap #4 review comment: paginate_all_results() and all four callers
+(list_users, list_groups, list_group_users, get_logs) must handle SDK v3
+ApiResponse objects correctly via the Link-header cursor loop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from okta_mcp_server.utils.pagination import (
+    extract_after_cursor,
+    paginate_all_results,
+    create_paginated_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_v3_response(after_cursor: str | None = None, items: list | None = None):
+    """Return a minimal SDK v3 ApiResponse-like mock.
+
+    Args:
+        after_cursor: If provided, a ``Link`` header with rel="next" and the
+            given ``after`` query parameter is added.
+        items: Ignored here; kept for clarity at call-sites.
+    """
+    response = MagicMock()
+    # v3 responses do NOT have has_next / next
+    del response.has_next
+    del response.next
+
+    if after_cursor:
+        link_value = (
+            f'<https://test.okta.com/api/v1/users?after={after_cursor}&limit=20>; rel="next"'
+        )
+        response.headers = {"Link": link_value}
+    else:
+        response.headers = {}
+    return response
+
+
+def _make_v2_response(has_next: bool = False, next_url: str | None = None):
+    """Return a minimal SDK v2 OktaAPIResponse-like mock."""
+    response = MagicMock()
+    response.has_next = MagicMock(return_value=has_next)
+    response._next = next_url
+    return response
+
+
+def _make_items(n: int, prefix: str = "item") -> list:
+    return [MagicMock(name=f"{prefix}_{i}") for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# extract_after_cursor — SDK v3 path
+# ---------------------------------------------------------------------------
+
+class TestExtractAfterCursorV3:
+    def test_extracts_cursor_from_link_header(self):
+        response = _make_v3_response(after_cursor="abc123")
+        assert extract_after_cursor(response) == "abc123"
+
+    def test_returns_none_when_no_link_header(self):
+        response = _make_v3_response(after_cursor=None)
+        assert extract_after_cursor(response) is None
+
+    def test_returns_none_when_link_header_has_no_next_rel(self):
+        response = MagicMock()
+        del response.has_next
+        response.headers = {'Link': '<https://example.com/prev>; rel="prev"'}
+        assert extract_after_cursor(response) is None
+
+    def test_returns_none_for_none_response(self):
+        assert extract_after_cursor(None) is None
+
+    def test_handles_lowercase_link_header_key(self):
+        response = MagicMock()
+        del response.has_next
+        response.headers = {
+            "link": '<https://test.okta.com/api/v1/users?after=xyz>; rel="next"'
+        }
+        assert extract_after_cursor(response) == "xyz"
+
+    def test_handles_multiple_link_rels(self):
+        response = MagicMock()
+        del response.has_next
+        response.headers = {
+            "Link": (
+                '<https://test.okta.com/api/v1/users?after=cursor99>; rel="next", '
+                '<https://test.okta.com/api/v1/users>; rel="self"'
+            )
+        }
+        assert extract_after_cursor(response) == "cursor99"
+
+
+# ---------------------------------------------------------------------------
+# extract_after_cursor — SDK v2 path
+# ---------------------------------------------------------------------------
+
+class TestExtractAfterCursorV2:
+    def test_extracts_cursor_from_next_url(self):
+        response = _make_v2_response(
+            has_next=True,
+            next_url="/api/v1/users?after=v2cursor&limit=200",
+        )
+        assert extract_after_cursor(response) == "v2cursor"
+
+    def test_returns_none_when_has_next_false(self):
+        response = _make_v2_response(has_next=False)
+        assert extract_after_cursor(response) is None
+
+    def test_returns_none_when_no_next_url(self):
+        response = _make_v2_response(has_next=True, next_url=None)
+        assert extract_after_cursor(response) is None
+
+
+# ---------------------------------------------------------------------------
+# paginate_all_results — SDK v3 path (fetch_page_fn provided)
+# ---------------------------------------------------------------------------
+
+class TestPaginateAllResultsV3:
+    @pytest.mark.asyncio
+    async def test_single_page_no_next_cursor(self):
+        """When there is no next cursor, only the initial page is returned."""
+        initial_response = _make_v3_response(after_cursor=None)
+        initial_items = _make_items(5)
+
+        all_items, info = await paginate_all_results(
+            initial_response,
+            initial_items,
+            fetch_page_fn=AsyncMock(),  # should never be called
+        )
+
+        assert all_items == initial_items
+        assert info["pages_fetched"] == 1
+        assert info["stopped_early"] is False
+        assert info["stop_reason"] is None
+
+    @pytest.mark.asyncio
+    async def test_multi_page_fetches_all_pages(self):
+        """Two pages of results are stitched together correctly."""
+        page1_items = _make_items(5, "page1")
+        page2_items = _make_items(3, "page2")
+
+        # Response for page 1 has a next cursor; page 2 has none
+        resp1 = _make_v3_response(after_cursor="cursor_for_page2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        fetch_page_fn = AsyncMock(return_value=(page2_items, resp2, None))
+
+        all_items, info = await paginate_all_results(
+            resp1,
+            page1_items,
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        fetch_page_fn.assert_awaited_once_with("cursor_for_page2")
+        assert all_items == page1_items + page2_items
+        assert info["pages_fetched"] == 2
+        assert info["total_items"] == 8
+        assert info["stopped_early"] is False
+
+    @pytest.mark.asyncio
+    async def test_three_pages(self):
+        page1 = _make_items(3, "p1")
+        page2 = _make_items(3, "p2")
+        page3 = _make_items(2, "p3")
+
+        resp1 = _make_v3_response(after_cursor="c2")
+        resp2 = _make_v3_response(after_cursor="c3")
+        resp3 = _make_v3_response(after_cursor=None)
+
+        fetch_page_fn = AsyncMock(side_effect=[
+            (page2, resp2, None),
+            (page3, resp3, None),
+        ])
+
+        all_items, info = await paginate_all_results(resp1, page1, fetch_page_fn=fetch_page_fn)
+
+        assert len(all_items) == 8
+        assert info["pages_fetched"] == 3
+        assert info["stopped_early"] is False
+
+    @pytest.mark.asyncio
+    async def test_stops_at_max_pages(self):
+        """Pagination stops at max_pages and sets stopped_early=True."""
+        # Each response always has a next cursor → infinite pages
+        resp_with_cursor = _make_v3_response(after_cursor="always_more")
+        page_items = _make_items(5)
+
+        fetch_page_fn = AsyncMock(return_value=(page_items, resp_with_cursor, None))
+
+        all_items, info = await paginate_all_results(
+            resp_with_cursor,
+            page_items,
+            max_pages=3,
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        assert info["pages_fetched"] == 3
+        assert info["stopped_early"] is True
+        assert "maximum page limit" in info["stop_reason"]
+        assert len(all_items) == 15  # 3 pages × 5 items
+
+    @pytest.mark.asyncio
+    async def test_api_error_mid_pagination_returns_partial_results(self):
+        """When the API returns an error mid-way, partial results are returned."""
+        page1_items = _make_items(5, "p1")
+        resp1 = _make_v3_response(after_cursor="c2")
+
+        fetch_page_fn = AsyncMock(return_value=(None, MagicMock(), "Okta API error"))
+
+        all_items, info = await paginate_all_results(
+            resp1,
+            page1_items,
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        assert all_items == page1_items  # only first page
+        assert info["stopped_early"] is True
+        assert "API error" in info["stop_reason"]
+
+    @pytest.mark.asyncio
+    async def test_exception_during_fetch_page_returns_partial_results(self):
+        """An exception during a page fetch stops pagination gracefully."""
+        page1_items = _make_items(4, "p1")
+        resp1 = _make_v3_response(after_cursor="c2")
+
+        fetch_page_fn = AsyncMock(side_effect=RuntimeError("network failure"))
+
+        all_items, info = await paginate_all_results(
+            resp1,
+            page1_items,
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        assert all_items == page1_items
+        assert info["stopped_early"] is True
+        assert "Exception" in info["stop_reason"]
+
+    @pytest.mark.asyncio
+    async def test_empty_next_page_stops_loop(self):
+        """If the next page returns no items, pagination terminates cleanly."""
+        page1_items = _make_items(5, "p1")
+        resp1 = _make_v3_response(after_cursor="c2")
+        resp2 = _make_v3_response(after_cursor="c3")  # has cursor but empty items
+
+        fetch_page_fn = AsyncMock(return_value=([], resp2, None))
+
+        all_items, info = await paginate_all_results(
+            resp1,
+            page1_items,
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        assert all_items == page1_items
+        assert info["pages_fetched"] == 1
+        assert info["stopped_early"] is False
+
+    @pytest.mark.asyncio
+    async def test_initial_empty_items(self):
+        """An empty initial page still participates in pagination correctly."""
+        resp1 = _make_v3_response(after_cursor="c2")
+        page2_items = _make_items(3, "p2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        fetch_page_fn = AsyncMock(return_value=(page2_items, resp2, None))
+
+        all_items, info = await paginate_all_results(
+            resp1,
+            [],
+            fetch_page_fn=fetch_page_fn,
+        )
+
+        assert all_items == page2_items
+        assert info["pages_fetched"] == 2
+
+
+# ---------------------------------------------------------------------------
+# paginate_all_results — SDK v2 fallback path (no fetch_page_fn)
+# ---------------------------------------------------------------------------
+
+class TestPaginateAllResultsV2Fallback:
+    @pytest.mark.asyncio
+    async def test_v2_multi_page_pagination(self):
+        page1 = _make_items(5, "p1")
+        page2 = _make_items(3, "p2")
+
+        resp = _make_v2_response(has_next=True)
+        # .next() called once, then has_next returns False
+        resp.has_next.side_effect = [True, False]
+        resp.next = AsyncMock(return_value=(page2, None))
+
+        all_items, info = await paginate_all_results(resp, page1)
+
+        assert all_items == page1 + page2
+        assert info["pages_fetched"] == 2
+        assert info["stopped_early"] is False
+
+    @pytest.mark.asyncio
+    async def test_v2_no_next_page(self):
+        page1 = _make_items(5)
+        resp = _make_v2_response(has_next=False)
+
+        all_items, info = await paginate_all_results(resp, page1)
+
+        assert all_items == page1
+        assert info["pages_fetched"] == 1
+
+    @pytest.mark.asyncio
+    async def test_v2_api_error_mid_pagination(self):
+        page1 = _make_items(3)
+        resp = _make_v2_response(has_next=True)
+        resp.has_next.return_value = True
+        resp.next = AsyncMock(return_value=(None, "v2 error"))
+
+        all_items, info = await paginate_all_results(resp, page1)
+
+        assert all_items == page1
+        assert info["stopped_early"] is True
+        assert "API error" in info["stop_reason"]
+
+
+# ---------------------------------------------------------------------------
+# create_paginated_response
+# ---------------------------------------------------------------------------
+
+class TestCreatePaginatedResponse:
+    def test_single_page_no_fetch_all(self):
+        items = _make_items(5)
+        resp = _make_v3_response(after_cursor="abc")
+        result = create_paginated_response(items, resp, fetch_all_used=False)
+
+        assert result["total_fetched"] == 5
+        assert result["fetch_all_used"] is False
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "abc"
+
+    def test_fetch_all_suppresses_has_more(self):
+        items = _make_items(10)
+        resp = _make_v3_response(after_cursor="xyz")
+        result = create_paginated_response(items, resp, fetch_all_used=True)
+
+        assert result["fetch_all_used"] is True
+        assert result["has_more"] is False
+        assert result["next_cursor"] is None
+
+    def test_includes_pagination_info_when_provided(self):
+        items = _make_items(3)
+        resp = _make_v3_response()
+        info = {"pages_fetched": 5, "total_items": 100, "stopped_early": True, "stop_reason": "limit"}
+        result = create_paginated_response(items, resp, fetch_all_used=True, pagination_info=info)
+
+        assert result["pagination_info"] == info
+
+    def test_no_pagination_info_key_when_not_provided(self):
+        items = _make_items(2)
+        resp = _make_v3_response()
+        result = create_paginated_response(items, resp, fetch_all_used=False)
+
+        assert "pagination_info" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tool integration: fetch_all=True guard + paginate_all_results call
+# Tests for list_users, list_groups, list_group_users, get_logs
+# ---------------------------------------------------------------------------
+
+def _make_ctx_with_client(client):
+    """Build a minimal Context mock wired to the given Okta client mock."""
+    manager = MagicMock()
+    ctx = MagicMock()
+    ctx.request_context.lifespan_context.okta_auth_manager = manager
+    return ctx, manager
+
+
+class TestListUsersFetchAll:
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_paginates_all_pages(self):
+        """list_users with fetch_all=True stitches multiple pages together."""
+        from okta_mcp_server.tools.users.users import list_users
+
+        page1_users = _make_items(3, "user")
+        for u in page1_users:
+            u.profile = MagicMock()
+            u.id = "id"
+
+        page2_users = _make_items(2, "user")
+        for u in page2_users:
+            u.profile = MagicMock()
+            u.id = "id"
+
+        resp1 = _make_v3_response(after_cursor="c2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        client = AsyncMock()
+        client.list_users.side_effect = [
+            (page1_users, resp1, None),
+            (page2_users, resp2, None),
+        ]
+
+        ctx, manager = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.users.users.get_okta_client", return_value=client):
+            result = await list_users(ctx, fetch_all=True, limit=3)
+
+        assert result["fetch_all_used"] is True
+        assert result["total_fetched"] == 5
+        assert result["pagination_info"]["pages_fetched"] == 2
+        assert result["pagination_info"]["stopped_early"] is False
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_false_returns_single_page(self):
+        """list_users with fetch_all=False returns only the first page."""
+        from okta_mcp_server.tools.users.users import list_users
+
+        users = _make_items(5, "user")
+        for u in users:
+            u.profile = MagicMock()
+            u.id = "id"
+
+        resp = _make_v3_response(after_cursor="more")
+        client = AsyncMock()
+        client.list_users.return_value = (users, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.users.users.get_okta_client", return_value=client):
+            result = await list_users(ctx, fetch_all=False)
+
+        assert result["fetch_all_used"] is False
+        assert result["total_fetched"] == 5
+        assert result["has_more"] is True
+        assert result["next_cursor"] == "more"
+        # list_users was only called once — no pagination
+        assert client.list_users.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_single_page_no_next_cursor(self):
+        """fetch_all=True on a single-page result: no extra requests made."""
+        from okta_mcp_server.tools.users.users import list_users
+
+        users = _make_items(4, "user")
+        for u in users:
+            u.profile = MagicMock()
+            u.id = "id"
+
+        resp = _make_v3_response(after_cursor=None)
+        client = AsyncMock()
+        client.list_users.return_value = (users, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.users.users.get_okta_client", return_value=client):
+            result = await list_users(ctx, fetch_all=True)
+
+        # Guard condition: no next cursor → no pagination attempted
+        assert client.list_users.call_count == 1
+        assert result["total_fetched"] == 4
+
+
+class TestListGroupsFetchAll:
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_paginates_all_pages(self):
+        from okta_mcp_server.tools.groups.groups import list_groups
+
+        page1 = _make_items(2, "grp")
+        page2 = _make_items(2, "grp")
+
+        resp1 = _make_v3_response(after_cursor="g2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        client = AsyncMock()
+        client.list_groups.side_effect = [
+            (page1, resp1, None),
+            (page2, resp2, None),
+        ]
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client):
+            result = await list_groups(ctx, fetch_all=True, limit=2)
+
+        assert result["fetch_all_used"] is True
+        assert result["total_fetched"] == 4
+        assert result["pagination_info"]["pages_fetched"] == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_false_returns_single_page(self):
+        from okta_mcp_server.tools.groups.groups import list_groups
+
+        groups = _make_items(3, "grp")
+        resp = _make_v3_response(after_cursor="gc")
+        client = AsyncMock()
+        client.list_groups.return_value = (groups, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client):
+            result = await list_groups(ctx, fetch_all=False)
+
+        assert result["fetch_all_used"] is False
+        assert result["total_fetched"] == 3
+        assert client.list_groups.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_max_pages_stops_early(self):
+        from okta_mcp_server.tools.groups.groups import list_groups
+
+        page_items = _make_items(5, "grp")
+        resp_with_cursor = _make_v3_response(after_cursor="always_more")
+
+        client = AsyncMock()
+        # Always return a new page with a cursor
+        client.list_groups.return_value = (page_items, resp_with_cursor, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with (
+            patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client),
+            patch("okta_mcp_server.utils.pagination.paginate_all_results") as mock_paginate,
+        ):
+            mock_paginate.return_value = (
+                page_items * 3,
+                {"pages_fetched": 3, "total_items": 15, "stopped_early": True,
+                 "stop_reason": "Reached maximum page limit (3)"},
+            )
+            result = await list_groups(ctx, fetch_all=True, limit=5)
+
+        assert result["pagination_info"]["stopped_early"] is True
+
+
+class TestListGroupUsersFetchAll:
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_paginates_all_pages(self):
+        from okta_mcp_server.tools.groups.groups import list_group_users
+
+        page1 = _make_items(3, "usr")
+        page2 = _make_items(2, "usr")
+
+        resp1 = _make_v3_response(after_cursor="uc2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        client = AsyncMock()
+        client.list_group_users.side_effect = [
+            (page1, resp1, None),
+            (page2, resp2, None),
+        ]
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client):
+            result = await list_group_users("grp1", ctx, fetch_all=True, limit=3)
+
+        assert result["fetch_all_used"] is True
+        assert result["total_fetched"] == 5
+        assert result["pagination_info"]["pages_fetched"] == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_false_returns_single_page(self):
+        from okta_mcp_server.tools.groups.groups import list_group_users
+
+        users = _make_items(4, "usr")
+        resp = _make_v3_response(after_cursor="uc")
+        client = AsyncMock()
+        client.list_group_users.return_value = (users, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client):
+            result = await list_group_users("grp1", ctx, fetch_all=False)
+
+        assert result["fetch_all_used"] is False
+        assert result["total_fetched"] == 4
+        assert client.list_group_users.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_passes_group_id_to_each_page(self):
+        """The group_id must be forwarded unchanged to every paginated request."""
+        from okta_mcp_server.tools.groups.groups import list_group_users
+
+        group_id = "00gABCDEFG"
+        page1 = _make_items(2, "usr")
+        page2 = _make_items(1, "usr")
+
+        resp1 = _make_v3_response(after_cursor="uc2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        client = AsyncMock()
+        client.list_group_users.side_effect = [
+            (page1, resp1, None),
+            (page2, resp2, None),
+        ]
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.groups.groups.get_okta_client", return_value=client):
+            await list_group_users(group_id, ctx, fetch_all=True)
+
+        # Both calls should use the same group_id
+        for call in client.list_group_users.call_args_list:
+            assert call.args[0] == group_id
+
+
+class TestGetLogsFetchAll:
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_paginates_all_pages(self):
+        from okta_mcp_server.tools.system_logs.system_logs import get_logs
+
+        page1 = _make_items(3, "log")
+        page2 = _make_items(2, "log")
+
+        resp1 = _make_v3_response(after_cursor="lc2")
+        resp2 = _make_v3_response(after_cursor=None)
+
+        client = AsyncMock()
+        client.list_log_events.side_effect = [
+            (page1, resp1, None),
+            (page2, resp2, None),
+        ]
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.system_logs.system_logs.get_okta_client", return_value=client):
+            result = await get_logs(ctx, fetch_all=True, limit=3)
+
+        assert result["fetch_all_used"] is True
+        assert result["total_fetched"] == 5
+        assert result["pagination_info"]["pages_fetched"] == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_false_returns_single_page(self):
+        from okta_mcp_server.tools.system_logs.system_logs import get_logs
+
+        logs = _make_items(5, "log")
+        resp = _make_v3_response(after_cursor="lc")
+        client = AsyncMock()
+        client.list_log_events.return_value = (logs, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.system_logs.system_logs.get_okta_client", return_value=client):
+            result = await get_logs(ctx, fetch_all=False)
+
+        assert result["fetch_all_used"] is False
+        assert result["total_fetched"] == 5
+        assert client.list_log_events.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_fetch_all_true_single_page_no_cursor(self):
+        """get_logs with fetch_all=True but only one page of results."""
+        from okta_mcp_server.tools.system_logs.system_logs import get_logs
+
+        logs = _make_items(2, "log")
+        resp = _make_v3_response(after_cursor=None)
+        client = AsyncMock()
+        client.list_log_events.return_value = (logs, resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.system_logs.system_logs.get_okta_client", return_value=client):
+            result = await get_logs(ctx, fetch_all=True)
+
+        assert client.list_log_events.call_count == 1
+        assert result["total_fetched"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_results_with_fetch_all(self):
+        """get_logs with fetch_all=True and zero results returns empty list."""
+        from okta_mcp_server.tools.system_logs.system_logs import get_logs
+
+        resp = _make_v3_response(after_cursor=None)
+        client = AsyncMock()
+        client.list_log_events.return_value = ([], resp, None)
+
+        ctx, _ = _make_ctx_with_client(client)
+
+        with patch("okta_mcp_server.tools.system_logs.system_logs.get_okta_client", return_value=client):
+            result = await get_logs(ctx, fetch_all=True)
+
+        assert result["total_fetched"] == 0
+        assert result["fetch_all_used"] is True
+
+
+# ---------------------------------------------------------------------------
+# Guard condition: v3 ApiResponse never has has_next attr
+# ---------------------------------------------------------------------------
+
+class TestGuardCondition:
+    """Verify that the guard uses extract_after_cursor(), NOT hasattr(response, 'has_next')."""
+
+    def test_v3_response_has_no_has_next(self):
+        """SDK v3 ApiResponse objects must NOT have a has_next attribute."""
+        resp = _make_v3_response(after_cursor="abc")
+        assert not hasattr(resp, "has_next"), (
+            "v3 ApiResponse must not have has_next; "
+            "the old guard condition would silently skip pagination"
+        )
+
+    def test_extract_after_cursor_works_on_v3_response(self):
+        """extract_after_cursor() must work on a v3 ApiResponse with a Link header."""
+        resp = _make_v3_response(after_cursor="abc123")
+        assert extract_after_cursor(resp) == "abc123"
+
+    def test_extract_after_cursor_returns_none_on_v3_no_cursor(self):
+        """extract_after_cursor() must return None on a v3 response without Link."""
+        resp = _make_v3_response(after_cursor=None)
+        assert extract_after_cursor(resp) is None

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -14,7 +14,12 @@ path traversal and injection attacks while allowing valid Okta IDs.
 
 import pytest
 
-from okta_mcp_server.utils.validation import InvalidOktaIdError, validate_okta_id
+from okta_mcp_server.utils.validation import (
+    InvalidOktaIdError,
+    _validate_os_version_string,
+    validate_okta_id,
+    validate_os_version_params,
+)
 
 
 class TestValidateOktaId:
@@ -159,3 +164,225 @@ class TestValidateOktaId:
         with pytest.raises(InvalidOktaIdError) as exc_info:
             validate_okta_id(malicious_id, "user_id")
         assert "forbidden" in str(exc_info.value).lower()
+
+
+# ===========================================================================
+# _validate_os_version_string
+# ===========================================================================
+
+class TestValidateOsVersionString:
+    """Tests for the _validate_os_version_string helper in validation.py."""
+
+    # --- Valid versions ---
+
+    def test_valid_xyz_returns_none(self):
+        assert _validate_os_version_string("14.2.1") is None
+
+    def test_valid_xyzw_returns_none(self):
+        assert _validate_os_version_string("14.2.1.0") is None
+
+    def test_empty_string_returns_none(self):
+        assert _validate_os_version_string("") is None
+
+    def test_android_single_component_accepted(self):
+        assert _validate_os_version_string("12", "ANDROID") is None
+
+    def test_android_single_component_zero_accepted(self):
+        assert _validate_os_version_string("9", "ANDROID") is None
+
+    def test_android_platform_case_insensitive(self):
+        assert _validate_os_version_string("12", "android") is None
+
+    # --- Two-component X.Y — must be rejected ---
+
+    def test_xy_returns_error(self):
+        error = _validate_os_version_string("14.2")
+        assert error is not None
+        assert "Incomplete" in error
+        assert "14.2" in error
+        assert "14.2.0" in error
+
+    def test_xy_error_warns_not_to_assume_patch(self):
+        error = _validate_os_version_string("14.2")
+        assert "Do NOT assume" in error
+
+    def test_xy_rejected_for_non_android_platform(self):
+        error = _validate_os_version_string("14.2", "MACOS")
+        assert error is not None
+        assert "Incomplete" in error
+
+    def test_xy_rejected_even_for_android(self):
+        # Two-component versions are not accepted for Android either —
+        # Android uses single major version only.
+        error = _validate_os_version_string("12.0", "ANDROID")
+        assert error is not None
+        assert "Incomplete" in error
+
+    def test_snake_case_not_applicable_to_string_helper(self):
+        # The string helper does not deal with dict keys; just validates the value.
+        assert _validate_os_version_string("14.2.1") is None
+
+    # --- Single-component for non-Android ---
+
+    def test_single_component_rejected_without_platform(self):
+        error = _validate_os_version_string("14")
+        assert error is not None
+        assert "Invalid" in error
+        assert "14" in error
+
+    def test_single_component_rejected_for_macos(self):
+        error = _validate_os_version_string("14", "MACOS")
+        assert error is not None
+        assert "Invalid" in error
+
+    # --- Garbage / alpha versions ---
+
+    def test_alpha_component_returns_error(self):
+        error = _validate_os_version_string("14.2.alpha")
+        assert error is not None
+
+    def test_leading_dot_returns_error(self):
+        error = _validate_os_version_string(".14.2.1")
+        assert error is not None
+
+    def test_completely_non_numeric_returns_error(self):
+        error = _validate_os_version_string("notaversion")
+        assert error is not None
+
+    def test_error_message_contains_xyz_format_hint(self):
+        error = _validate_os_version_string("abc")
+        assert error is not None
+        assert "X.Y.Z" in error
+
+    def test_error_message_mentions_android_exception(self):
+        error = _validate_os_version_string("14", "MACOS")
+        assert error is not None
+        assert "Android" in error
+
+
+# ===========================================================================
+# validate_os_version_params (decorator)
+# ===========================================================================
+
+class TestValidateOsVersionParams:
+    """Tests for the validate_os_version_params decorator in validation.py."""
+
+    # --- Direct string parameter ---
+
+    @pytest.mark.asyncio
+    async def test_valid_xyz_string_param_passes(self):
+        @validate_os_version_params("ver")
+        async def tool(ver=None):
+            return {"ok": True}
+        result = await tool(ver="14.2.1")
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_xy_string_param_rejected(self):
+        @validate_os_version_params("ver")
+        async def tool(ver=None):
+            return {"ok": True}
+        result = await tool(ver="14.2")
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+        assert "14.2.0" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_none_string_param_skipped(self):
+        @validate_os_version_params("ver")
+        async def tool(ver=None):
+            return {"ok": True}
+        result = await tool(ver=None)
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_invalid_string_param_rejected(self):
+        @validate_os_version_params("ver")
+        async def tool(ver=None):
+            return {"ok": True}
+        result = await tool(ver="notaversion")
+        assert "error" in result
+
+    # --- Dict / policy_data parameter ---
+
+    @pytest.mark.asyncio
+    async def test_valid_policy_data_version_passes(self):
+        @validate_os_version_params("policy_data")
+        async def tool(policy_data):
+            return {"ok": True}
+        result = await tool(policy_data={"platform": "MACOS", "osVersion": {"minimum": "14.2.1"}})
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_xy_policy_data_version_rejected(self):
+        @validate_os_version_params("policy_data")
+        async def tool(policy_data):
+            return {"ok": True}
+        result = await tool(policy_data={"platform": "MACOS", "osVersion": {"minimum": "14.2"}})
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+        assert "Do NOT assume" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_snake_case_os_version_key_in_dict_rejected(self):
+        @validate_os_version_params("policy_data")
+        async def tool(policy_data):
+            return {"ok": True}
+        result = await tool(policy_data={"platform": "MACOS", "os_version": {"minimum": "17.0"}})
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_policy_data_without_os_version_passes(self):
+        @validate_os_version_params("policy_data")
+        async def tool(policy_data):
+            return {"ok": True}
+        result = await tool(policy_data={"platform": "MACOS", "name": "My Policy"})
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_android_single_component_in_policy_data_passes(self):
+        @validate_os_version_params("policy_data")
+        async def tool(policy_data):
+            return {"ok": True}
+        result = await tool(policy_data={"platform": "ANDROID", "osVersion": {"minimum": "12"}})
+        assert result == {"ok": True}
+
+    # --- error_return_type="list" ---
+
+    @pytest.mark.asyncio
+    async def test_list_return_type_on_error(self):
+        @validate_os_version_params("ver", error_return_type="list")
+        async def tool(ver=None):
+            return ["ok"]
+        result = await tool(ver="14.2")
+        assert isinstance(result, list)
+        assert result[0].startswith("Error:")
+
+    # --- Sync function support ---
+
+    def test_sync_function_xy_rejected(self):
+        @validate_os_version_params("ver")
+        def tool(ver=None):
+            return {"ok": True}
+        result = tool(ver="14.2")
+        assert "error" in result
+        assert "Incomplete" in result["error"]
+
+    def test_sync_function_valid_version_passes(self):
+        @validate_os_version_params("ver")
+        def tool(ver=None):
+            return {"ok": True}
+        result = tool(ver="14.2.1")
+        assert result == {"ok": True}
+
+    # --- Parameter not present in call ---
+
+    @pytest.mark.asyncio
+    async def test_missing_param_name_skipped(self):
+        @validate_os_version_params("nonexistent")
+        async def tool(ver=None):
+            return {"ok": True}
+        result = await tool(ver="14.2")
+        assert result == {"ok": True}
+

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.12.9"
+version = "3.13.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -33,37 +33,71 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/ad/5b0f3451c2275af09966f1d7c0965facd4729a5b7efdc2eb728654679f85/aiohttp-3.12.9.tar.gz", hash = "sha256:2c9914c8914ff40b68c6e4ed5da33e88d4e8f368fddd03ceb0eb3175905ca782", size = 7810207, upload-time = "2025-06-04T16:26:40.157Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/42/32cf8e7704ceb4481406eb87161349abb46a57fee3f008ba9cb610968646/aiohttp-3.13.3.tar.gz", hash = "sha256:a949eee43d3782f2daae4f4a2819b2cb9b0c5d3b7f7a927067cc84dafdbb9f88", size = 7844556, upload-time = "2026-01-03T17:33:05.204Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5e/e7ee4927e72d65b68f612ca2013800c91aab38fd1f487926c2a8e4f1c8ea/aiohttp-3.12.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:bf6fac88666d7e4c6cfe649d133fcedbc68e37a4472e8662d98a7cf576207303", size = 693344, upload-time = "2025-06-04T16:25:11.187Z" },
-    { url = "https://files.pythonhosted.org/packages/65/b5/f1dfda86a66913bfa9b7c3fe30d13f4d5a3642d3176ad0019968cda35d97/aiohttp-3.12.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:74e87ea6c832311b18a32b06baa6fee90a83dd630de951cca1aa175c3c9fa1ce", size = 471005, upload-time = "2025-06-04T16:25:13.924Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e2/1502272a6e98665c71f9e996f126b64598c6e1660804eb4d78cad7ab3106/aiohttp-3.12.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16627b4caf6a36b605e3e1c4847e6d14af8e8d6b7dad322935be43237d4eb10d", size = 463304, upload-time = "2025-06-04T16:25:16.171Z" },
-    { url = "https://files.pythonhosted.org/packages/88/38/5c308d02754e346ca9eae63a086f438aae9a4fc36cdd1708fe41588b3883/aiohttp-3.12.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:998e323c107c3f6396c1f9de72289009057c611942771f24114ae78a76af0af5", size = 1702124, upload-time = "2025-06-04T16:25:18.701Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/25/ab0af26f80c1b6035794d1c769d5671f7ecb59c93b64ea7dfced28df0dca/aiohttp-3.12.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:20f8a6d3af13f043a09726add6d096b533f180cf8b43970a8d9c9ca978bf45c5", size = 1683390, upload-time = "2025-06-04T16:25:20.98Z" },
-    { url = "https://files.pythonhosted.org/packages/23/fa/9a510d5ec8e1a75008a1c0e985e1db2ce339b9f82d838c7598b85f8f16d4/aiohttp-3.12.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0bd0e06c8626361027f69df510c8484e17568ba2f91b2de51ea055f86ed3b071", size = 1735458, upload-time = "2025-06-04T16:25:23.864Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b2/870cabf883512f0f2cd9505bd7bce1e4574d137f132ab8d597ac5367b0ee/aiohttp-3.12.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:64e22f12dd940a6e7b923637b10b611b752f6117bc3a780b7e61cc43c9e04892", size = 1784830, upload-time = "2025-06-04T16:25:26.212Z" },
-    { url = "https://files.pythonhosted.org/packages/68/cd/ab572264f5efbb8059f40d92d411918215bc4e669a7684bfa1ea0617745d/aiohttp-3.12.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11b5bf453056b6ac4924ede1188d01e8b8d4801a6aa5351da3a7dbdbc03cb44e", size = 1707162, upload-time = "2025-06-04T16:25:28.663Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6f/8a6a1dedb8ee5a4034e49bb3cb81ced4fe239d4d047f6bab538320fcb5bc/aiohttp-3.12.9-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:00369db59f09860e0e26c75035f80f92881103e90f5858c18f29eb4f8cb8970f", size = 1620865, upload-time = "2025-06-04T16:25:31.092Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cf/6b7ab3b221a900a62e8cf26a47476377278675191aa2ea28327ba105c5c9/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:80fa1efc71d423be25db9dddefe8dcd90e487fbc9351a59549521b66405e71de", size = 1673887, upload-time = "2025-06-04T16:25:33.577Z" },
-    { url = "https://files.pythonhosted.org/packages/16/5c/aaa1fe022e86291c34a4e15e41d7cad589b4bdd66d473d6d537420763ab2/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5cade22a0f0a4665003ded2bc4d43bb69fde790e5a287187569509c33333a3ab", size = 1705551, upload-time = "2025-06-04T16:25:36.053Z" },
-    { url = "https://files.pythonhosted.org/packages/86/bf/0f7393a2ef0df4464945c3081d0629a9cb9bfaefaaa922dba225f7c47824/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d4a0fe3cd45cf6fb18222deef92af1c3efe090b7f43d477de61b2360c90a4b32", size = 1648148, upload-time = "2025-06-04T16:25:38.961Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/71/286923ff54ae69c54e84bfbcc741b5833d980f192a93438f8d6cf153dae8/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:97b036ce251825fd5ab69d302ca8a99d3352af1c616cf40b2306fdb734cd6d30", size = 1724280, upload-time = "2025-06-04T16:25:41.423Z" },
-    { url = "https://files.pythonhosted.org/packages/58/48/808167d6f115165da3fcc6b7bb49bce6cc648471aa30634bcd47a7c96a32/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:eeac3a965552dbf79bcc0b9b963b5f7d6364b1542eb609937278d70d27ae997f", size = 1757753, upload-time = "2025-06-04T16:25:43.893Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/1b/949e7965d642cdd82c7d9576fd27c24b27f4e0e35586fceb81057a99f617/aiohttp-3.12.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a1f72b2560beaa949b5d3b324fc07b66846d39a8e7cc106ca450312a5771e3e", size = 1706642, upload-time = "2025-06-04T16:25:46.299Z" },
-    { url = "https://files.pythonhosted.org/packages/90/43/ea621cb45fc0e3e0a7906a1fdfd7a3176892c29e4e3d9d4dfa05159ac485/aiohttp-3.12.9-cp313-cp313-win32.whl", hash = "sha256:e429fce99ac3fd6423622713d2474a5911f24816ccdaf9a74c3ece854b7375c1", size = 419167, upload-time = "2025-06-04T16:25:49.178Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/02/452bfb8285b980e463ca35c9d57b333a4defbb603983709dacfd27ca49a1/aiohttp-3.12.9-cp313-cp313-win_amd64.whl", hash = "sha256:ccb1931cc8b4dc6d7a2d83db39db18c3f9ac3d46a59289cea301acbad57f3d12", size = 445108, upload-time = "2025-06-04T16:25:51.544Z" },
+    { url = "https://files.pythonhosted.org/packages/97/8a/12ca489246ca1faaf5432844adbfce7ff2cc4997733e0af120869345643a/aiohttp-3.13.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5dff64413671b0d3e7d5918ea490bdccb97a4ad29b3f311ed423200b2203e01c", size = 734190, upload-time = "2026-01-03T17:30:45.832Z" },
+    { url = "https://files.pythonhosted.org/packages/32/08/de43984c74ed1fca5c014808963cc83cb00d7bb06af228f132d33862ca76/aiohttp-3.13.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:87b9aab6d6ed88235aa2970294f496ff1a1f9adcd724d800e9b952395a80ffd9", size = 491783, upload-time = "2026-01-03T17:30:47.466Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f8/8dd2cf6112a5a76f81f81a5130c57ca829d101ad583ce57f889179accdda/aiohttp-3.13.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:425c126c0dc43861e22cb1c14ba4c8e45d09516d0a3ae0a3f7494b79f5f233a3", size = 490704, upload-time = "2026-01-03T17:30:49.373Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/40/a46b03ca03936f832bc7eaa47cfbb1ad012ba1be4790122ee4f4f8cba074/aiohttp-3.13.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f9120f7093c2a32d9647abcaf21e6ad275b4fbec5b55969f978b1a97c7c86bf", size = 1720652, upload-time = "2026-01-03T17:30:50.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7e/917fe18e3607af92657e4285498f500dca797ff8c918bd7d90b05abf6c2a/aiohttp-3.13.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:697753042d57f4bf7122cab985bf15d0cef23c770864580f5af4f52023a56bd6", size = 1692014, upload-time = "2026-01-03T17:30:52.729Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b6/cefa4cbc00d315d68973b671cf105b21a609c12b82d52e5d0c9ae61d2a09/aiohttp-3.13.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6de499a1a44e7de70735d0b39f67c8f25eb3d91eb3103be99ca0fa882cdd987d", size = 1759777, upload-time = "2026-01-03T17:30:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e3/e06ee07b45e59e6d81498b591fc589629be1553abb2a82ce33efe2a7b068/aiohttp-3.13.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:37239e9f9a7ea9ac5bf6b92b0260b01f8a22281996da609206a84df860bc1261", size = 1861276, upload-time = "2026-01-03T17:30:56.512Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/24/75d274228acf35ceeb2850b8ce04de9dd7355ff7a0b49d607ee60c29c518/aiohttp-3.13.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f76c1e3fe7d7c8afad7ed193f89a292e1999608170dcc9751a7462a87dfd5bc0", size = 1743131, upload-time = "2026-01-03T17:30:58.256Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/3d21dde21889b17ca2eea54fdcff21b27b93f45b7bb94ca029c31ab59dc3/aiohttp-3.13.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fc290605db2a917f6e81b0e1e0796469871f5af381ce15c604a3c5c7e51cb730", size = 1556863, upload-time = "2026-01-03T17:31:00.445Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/da0c3ab1192eaf64782b03971ab4055b475d0db07b17eff925e8c93b3aa5/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4021b51936308aeea0367b8f006dc999ca02bc118a0cc78c303f50a2ff6afb91", size = 1682793, upload-time = "2026-01-03T17:31:03.024Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0f/5802ada182f575afa02cbd0ec5180d7e13a402afb7c2c03a9aa5e5d49060/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:49a03727c1bba9a97d3e93c9f93ca03a57300f484b6e935463099841261195d3", size = 1716676, upload-time = "2026-01-03T17:31:04.842Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/8c/714d53bd8b5a4560667f7bbbb06b20c2382f9c7847d198370ec6526af39c/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3d9908a48eb7416dc1f4524e69f1d32e5d90e3981e4e37eb0aa1cd18f9cfa2a4", size = 1733217, upload-time = "2026-01-03T17:31:06.868Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/e2176f46d2e963facea939f5be2d26368ce543622be6f00a12844d3c991f/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2712039939ec963c237286113c68dbad80a82a4281543f3abf766d9d73228998", size = 1552303, upload-time = "2026-01-03T17:31:08.958Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/6a/28ed4dea1759916090587d1fe57087b03e6c784a642b85ef48217b0277ae/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:7bfdc049127717581866fa4708791220970ce291c23e28ccf3922c700740fdc0", size = 1763673, upload-time = "2026-01-03T17:31:10.676Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/35/4a3daeb8b9fab49240d21c04d50732313295e4bd813a465d840236dd0ce1/aiohttp-3.13.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8057c98e0c8472d8846b9c79f56766bcc57e3e8ac7bfd510482332366c56c591", size = 1721120, upload-time = "2026-01-03T17:31:12.575Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9f/d643bb3c5fb99547323e635e251c609fbbc660d983144cfebec529e09264/aiohttp-3.13.3-cp313-cp313-win32.whl", hash = "sha256:1449ceddcdbcf2e0446957863af03ebaaa03f94c090f945411b61269e2cb5daf", size = 427383, upload-time = "2026-01-03T17:31:14.382Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f1/ab0395f8a79933577cdd996dd2f9aa6014af9535f65dddcf88204682fe62/aiohttp-3.13.3-cp313-cp313-win_amd64.whl", hash = "sha256:693781c45a4033d31d4187d2436f5ac701e7bbfe5df40d917736108c1cc7436e", size = 453899, upload-time = "2026-01-03T17:31:15.958Z" },
+    { url = "https://files.pythonhosted.org/packages/99/36/5b6514a9f5d66f4e2597e40dea2e3db271e023eb7a5d22defe96ba560996/aiohttp-3.13.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:ea37047c6b367fd4bd632bff8077449b8fa034b69e812a18e0132a00fae6e808", size = 737238, upload-time = "2026-01-03T17:31:17.909Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/49/459327f0d5bcd8c6c9ca69e60fdeebc3622861e696490d8674a6d0cb90a6/aiohttp-3.13.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6fc0e2337d1a4c3e6acafda6a78a39d4c14caea625124817420abceed36e2415", size = 492292, upload-time = "2026-01-03T17:31:19.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/0b/b97660c5fd05d3495b4eb27f2d0ef18dc1dc4eff7511a9bf371397ff0264/aiohttp-3.13.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c685f2d80bb67ca8c3837823ad76196b3694b0159d232206d1e461d3d434666f", size = 493021, upload-time = "2026-01-03T17:31:21.636Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d4/438efabdf74e30aeceb890c3290bbaa449780583b1270b00661126b8aae4/aiohttp-3.13.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48e377758516d262bde50c2584fc6c578af272559c409eecbdd2bae1601184d6", size = 1717263, upload-time = "2026-01-03T17:31:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/71/f2/7bddc7fd612367d1459c5bcf598a9e8f7092d6580d98de0e057eb42697ad/aiohttp-3.13.3-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:34749271508078b261c4abb1767d42b8d0c0cc9449c73a4df494777dc55f0687", size = 1669107, upload-time = "2026-01-03T17:31:25.334Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5a/1aeaecca40e22560f97610a329e0e5efef5e0b5afdf9f857f0d93839ab2e/aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26", size = 1760196, upload-time = "2026-01-03T17:31:27.394Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f8/0ff6992bea7bd560fc510ea1c815f87eedd745fe035589c71ce05612a19a/aiohttp-3.13.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2fff83cfc93f18f215896e3a190e8e5cb413ce01553901aca925176e7568963a", size = 1843591, upload-time = "2026-01-03T17:31:29.238Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d1/e30e537a15f53485b61f5be525f2157da719819e8377298502aebac45536/aiohttp-3.13.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bbe7d4cecacb439e2e2a8a1a7b935c25b812af7a5fd26503a66dadf428e79ec1", size = 1720277, upload-time = "2026-01-03T17:31:31.053Z" },
+    { url = "https://files.pythonhosted.org/packages/84/45/23f4c451d8192f553d38d838831ebbc156907ea6e05557f39563101b7717/aiohttp-3.13.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b928f30fe49574253644b1ca44b1b8adbd903aa0da4b9054a6c20fc7f4092a25", size = 1548575, upload-time = "2026-01-03T17:31:32.87Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ed/0a42b127a43712eda7807e7892c083eadfaf8429ca8fb619662a530a3aab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5e8fe4de30df199155baaf64f2fcd604f4c678ed20910db8e2c66dc4b11603", size = 1679455, upload-time = "2026-01-03T17:31:34.76Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b5/c05f0c2b4b4fe2c9d55e73b6d3ed4fd6c9dc2684b1d81cbdf77e7fad9adb/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:8542f41a62bcc58fc7f11cf7c90e0ec324ce44950003feb70640fc2a9092c32a", size = 1687417, upload-time = "2026-01-03T17:31:36.699Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6b/915bc5dad66aef602b9e459b5a973529304d4e89ca86999d9d75d80cbd0b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5e1d8c8b8f1d91cd08d8f4a3c2b067bfca6ec043d3ff36de0f3a715feeedf926", size = 1729968, upload-time = "2026-01-03T17:31:38.622Z" },
+    { url = "https://files.pythonhosted.org/packages/11/3b/e84581290a9520024a08640b63d07673057aec5ca548177a82026187ba73/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:90455115e5da1c3c51ab619ac57f877da8fd6d73c05aacd125c5ae9819582aba", size = 1545690, upload-time = "2026-01-03T17:31:40.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/04/0c3655a566c43fd647c81b895dfe361b9f9ad6d58c19309d45cff52d6c3b/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:042e9e0bcb5fba81886c8b4fbb9a09d6b8a00245fd8d88e4d989c1f96c74164c", size = 1746390, upload-time = "2026-01-03T17:31:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/71165b26978f719c3419381514c9690bd5980e764a09440a10bb816ea4ab/aiohttp-3.13.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2eb752b102b12a76ca02dff751a801f028b4ffbbc478840b473597fc91a9ed43", size = 1702188, upload-time = "2026-01-03T17:31:44.984Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a7/cbe6c9e8e136314fa1980da388a59d2f35f35395948a08b6747baebb6aa6/aiohttp-3.13.3-cp314-cp314-win32.whl", hash = "sha256:b556c85915d8efaed322bf1bdae9486aa0f3f764195a0fb6ee962e5c71ef5ce1", size = 433126, upload-time = "2026-01-03T17:31:47.463Z" },
+    { url = "https://files.pythonhosted.org/packages/de/56/982704adea7d3b16614fc5936014e9af85c0e34b58f9046655817f04306e/aiohttp-3.13.3-cp314-cp314-win_amd64.whl", hash = "sha256:9bf9f7a65e7aa20dd764151fb3d616c81088f91f8df39c3893a536e279b4b984", size = 459128, upload-time = "2026-01-03T17:31:49.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/2a/3c79b638a9c3d4658d345339d22070241ea341ed4e07b5ac60fb0f418003/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:05861afbbec40650d8a07ea324367cb93e9e8cc7762e04dd4405df99fa65159c", size = 769512, upload-time = "2026-01-03T17:31:51.134Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b9/3e5014d46c0ab0db8707e0ac2711ed28c4da0218c358a4e7c17bae0d8722/aiohttp-3.13.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2fc82186fadc4a8316768d61f3722c230e2c1dcab4200d52d2ebdf2482e47592", size = 506444, upload-time = "2026-01-03T17:31:52.85Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/c1d4ef9a054e151cd7839cdc497f2638f00b93cbe8043983986630d7a80c/aiohttp-3.13.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0add0900ff220d1d5c5ebbf99ed88b0c1bbf87aa7e4262300ed1376a6b13414f", size = 510798, upload-time = "2026-01-03T17:31:54.91Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/76/8c1e5abbfe8e127c893fe7ead569148a4d5a799f7cf958d8c09f3eedf097/aiohttp-3.13.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:568f416a4072fbfae453dcf9a99194bbb8bdeab718e08ee13dfa2ba0e4bebf29", size = 1868835, upload-time = "2026-01-03T17:31:56.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/984c5a6f74c363b01ff97adc96a3976d9c98940b8969a1881575b279ac5d/aiohttp-3.13.3-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:add1da70de90a2569c5e15249ff76a631ccacfe198375eead4aadf3b8dc849dc", size = 1720486, upload-time = "2026-01-03T17:31:58.65Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9a/b7039c5f099c4eb632138728828b33428585031a1e658d693d41d07d89d1/aiohttp-3.13.3-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b47b7ba335d2e9b1239fa571131a87e2d8ec96b333e68b2a305e7a98b0bae2", size = 1847951, upload-time = "2026-01-03T17:32:00.989Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/02/3bec2b9a1ba3c19ff89a43a19324202b8eb187ca1e928d8bdac9bbdddebd/aiohttp-3.13.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4dce1c718e38081c8f35f323209d4c1df7d4db4bab1b5c88a6b4d12b74587", size = 1941001, upload-time = "2026-01-03T17:32:03.122Z" },
+    { url = "https://files.pythonhosted.org/packages/37/df/d879401cedeef27ac4717f6426c8c36c3091c6e9f08a9178cc87549c537f/aiohttp-3.13.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34bac00a67a812570d4a460447e1e9e06fae622946955f939051e7cc895cfab8", size = 1797246, upload-time = "2026-01-03T17:32:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/15/be122de1f67e6953add23335c8ece6d314ab67c8bebb3f181063010795a7/aiohttp-3.13.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a19884d2ee70b06d9204b2727a7b9f983d0c684c650254679e716b0b77920632", size = 1627131, upload-time = "2026-01-03T17:32:07.607Z" },
+    { url = "https://files.pythonhosted.org/packages/12/12/70eedcac9134cfa3219ab7af31ea56bc877395b1ac30d65b1bc4b27d0438/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ca7f2bb6ba8348a3614c7918cc4bb73268c5ac2a207576b7afea19d3d9f64", size = 1795196, upload-time = "2026-01-03T17:32:09.59Z" },
+    { url = "https://files.pythonhosted.org/packages/32/11/b30e1b1cd1f3054af86ebe60df96989c6a414dd87e27ad16950eee420bea/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b0d95340658b9d2f11d9697f59b3814a9d3bb4b7a7c20b131df4bcef464037c0", size = 1782841, upload-time = "2026-01-03T17:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/88/0d/d98a9367b38912384a17e287850f5695c528cff0f14f791ce8ee2e4f7796/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:a1e53262fd202e4b40b70c3aff944a8155059beedc8a89bba9dc1f9ef06a1b56", size = 1795193, upload-time = "2026-01-03T17:32:13.705Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/a2dfd1f5ff5581632c7f6a30e1744deda03808974f94f6534241ef60c751/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:d60ac9663f44168038586cab2157e122e46bdef09e9368b37f2d82d354c23f72", size = 1621979, upload-time = "2026-01-03T17:32:15.965Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/12973c382ae7c1cccbc4417e129c5bf54c374dfb85af70893646e1f0e749/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:90751b8eed69435bac9ff4e3d2f6b3af1f57e37ecb0fbeee59c0174c9e2d41df", size = 1822193, upload-time = "2026-01-03T17:32:18.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5f/24155e30ba7f8c96918af1350eb0663e2430aad9e001c0489d89cd708ab1/aiohttp-3.13.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fc353029f176fd2b3ec6cfc71be166aba1936fe5d73dd1992ce289ca6647a9aa", size = 1769801, upload-time = "2026-01-03T17:32:20.25Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/7314031ff5c10e6ece114da79b338ec17eeff3a079e53151f7e9f43c4723/aiohttp-3.13.3-cp314-cp314t-win32.whl", hash = "sha256:2e41b18a58da1e474a057b3d35248d8320029f61d70a37629535b16a0c8f3767", size = 466523, upload-time = "2026-01-03T17:32:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/63/278a98c715ae467624eafe375542d8ba9b4383a016df8fdefe0ae28382a7/aiohttp-3.13.3-cp314-cp314t-win_amd64.whl", hash = "sha256:44531a36aa2264a1860089ffd4dce7baf875ee5a6079d5fb42e261c704ef7344", size = 499694, upload-time = "2026-01-03T17:32:24.546Z" },
 ]
 
 [[package]]
 name = "aiosignal"
-version = "1.3.2"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/b5/6d55e80f6d8a08ce22b982eafa278d823b541c925f11ee774b0b9c43473d/aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54", size = 19424, upload-time = "2024-12-13T17:10:40.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/6a/bc7e17a3e87a2985d3e8f4da4cd0f481060eb78fb08596c42be62c90a4d9/aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5", size = 7597, upload-time = "2024-12-13T17:10:38.469Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
 ]
 
 [[package]]
@@ -95,6 +129,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032, upload-time = "2025-03-13T11:10:22.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815, upload-time = "2025-03-13T11:10:21.14Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
 
 [[package]]
@@ -553,23 +596,26 @@ wheels = [
 
 [[package]]
 name = "okta"
-version = "2.9.13"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
     { name = "aiohttp" },
+    { name = "blinker" },
     { name = "flatdict" },
     { name = "jwcrypto" },
     { name = "pycryptodomex" },
+    { name = "pydantic" },
     { name = "pydash" },
     { name = "pyjwt" },
+    { name = "python-dateutil" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "xmltodict" },
-    { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/25/c896ce27690285ea67893b74049359695e182093b75cb8f0ed41e28006bc/okta-2.9.13.tar.gz", hash = "sha256:8d8e926751b7f8daae1794df2ec1b0e93f563b8b26781613d205cb9d10e837ef", size = 632952, upload-time = "2025-04-30T12:34:31.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/cf/6e9014b47a224a242d44132cb03bcde60fac15a7fa82ec354d9e36974805/okta-3.1.0.tar.gz", hash = "sha256:ed9603aeea7e1c9c65ace992046b160f82aef07465411e04ebca25590b5c6b38", size = 2171236, upload-time = "2026-01-30T10:19:23.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/54/d95f36554340cae6aee7ec51a146be7a7528d0e1876a0878566dabe95348/okta-2.9.13-py2.py3-none-any.whl", hash = "sha256:2dd389f5433511f15682547483eefa42e2168c20e696c344797f70cea2a44224", size = 556147, upload-time = "2025-04-30T12:33:53.122Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ac/c774a7fa5c94c61a7ef549b449ced35da0ea9629d5f7078cb0c2fafc1430/okta-3.1.0-py3-none-any.whl", hash = "sha256:d216b2ce4a5f6389d1d9cdd12eccd1c7f68cc37be38ec5e455fd94d69af7c697", size = 3820125, upload-time = "2026-01-30T10:19:19.717Z" },
 ]
 
 [[package]]
@@ -600,7 +646,7 @@ requires-dist = [
     { name = "keyrings-alt", specifier = ">=5.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
-    { name = "okta", specifier = ">=2.9.13" },
+    { name = "okta", specifier = ">=3.1.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
@@ -830,6 +876,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1038,6 +1096,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -596,13 +596,12 @@ wheels = [
 
 [[package]]
 name = "okta"
-version = "3.1.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
     { name = "aiohttp" },
     { name = "blinker" },
-    { name = "flatdict" },
     { name = "jwcrypto" },
     { name = "pycryptodomex" },
     { name = "pydantic" },
@@ -613,9 +612,9 @@ dependencies = [
     { name = "requests" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/cf/6e9014b47a224a242d44132cb03bcde60fac15a7fa82ec354d9e36974805/okta-3.1.0.tar.gz", hash = "sha256:ed9603aeea7e1c9c65ace992046b160f82aef07465411e04ebca25590b5c6b38", size = 2171236, upload-time = "2026-01-30T10:19:23.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6f/e087075ff2102f1519f367d1e72acd74f3cd5a01b4bda9266bea6afeb2f8/okta-3.3.0.tar.gz", hash = "sha256:e8f0df81fba7d3eb356f3fbf36e11707b338e40d822aae08e5d2e3a6efb474f7", size = 2303154, upload-time = "2026-03-27T10:34:23.107Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/ac/c774a7fa5c94c61a7ef549b449ced35da0ea9629d5f7078cb0c2fafc1430/okta-3.1.0-py3-none-any.whl", hash = "sha256:d216b2ce4a5f6389d1d9cdd12eccd1c7f68cc37be38ec5e455fd94d69af7c697", size = 3820125, upload-time = "2026-01-30T10:19:19.717Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3f/05dcc6d57e3f49ec348a46b6a8e17a29c723991610b8373d2e579dbb7850/okta-3.3.0-py3-none-any.whl", hash = "sha256:2d3cee33fa33e58091b92c692c4123a6c984d2972b2c61c72721fc855662bd46", size = 3886783, upload-time = "2026-03-27T10:34:16.972Z" },
 ]
 
 [[package]]
@@ -646,7 +645,7 @@ requires-dist = [
     { name = "keyrings-alt", specifier = ">=5.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
-    { name = "okta", specifier = ">=3.1.0" },
+    { name = "okta", specifier = "==3.3.0" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -596,7 +596,7 @@ wheels = [
 
 [[package]]
 name = "okta"
-version = "3.3.0"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -612,9 +612,9 @@ dependencies = [
     { name = "requests" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/6f/e087075ff2102f1519f367d1e72acd74f3cd5a01b4bda9266bea6afeb2f8/okta-3.3.0.tar.gz", hash = "sha256:e8f0df81fba7d3eb356f3fbf36e11707b338e40d822aae08e5d2e3a6efb474f7", size = 2303154, upload-time = "2026-03-27T10:34:23.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c8/562804ab31af3ffce89be36f50f898d88ff8b86a030d9908e2f82f52d012/okta-3.4.1.tar.gz", hash = "sha256:f36fe0d3d0980b413d5e83d1cc2c45bf0efcfe48fab0ecc6a276fc4cfbc99ad5", size = 2399204, upload-time = "2026-04-12T19:56:21.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/3f/05dcc6d57e3f49ec348a46b6a8e17a29c723991610b8373d2e579dbb7850/okta-3.3.0-py3-none-any.whl", hash = "sha256:2d3cee33fa33e58091b92c692c4123a6c984d2972b2c61c72721fc855662bd46", size = 3886783, upload-time = "2026-03-27T10:34:16.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/8d18569cf01814bcde3817ba2d42222f7b984b4efe622c94bcf9625973ee/okta-3.4.1-py3-none-any.whl", hash = "sha256:3ea2441516be23f30b4bad8b23e73bdf958604aa69eef8ca77898be25315e488", size = 3907643, upload-time = "2026-04-12T19:56:15.103Z" },
 ]
 
 [[package]]
@@ -645,7 +645,7 @@ requires-dist = [
     { name = "keyrings-alt", specifier = ">=5.0.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
-    { name = "okta", specifier = "==3.3.0" },
+    { name = "okta", specifier = "==3.4.1" },
     { name = "requests", specifier = ">=2.32.4" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]


### PR DESCRIPTION
## Changes

### New: Device Assurance Policy Tools

Adds 5 new MCP tools for managing Device Assurance Policies:

| Tool | Description |
|------|-------------|
| `list_device_assurance_policies` | List all policies with security attribute status |
| `get_device_assurance_policy` | Get a policy by ID |
| `create_device_assurance_policy` | Create a policy with OS version validation |
| `replace_device_assurance_policy` | Replace a policy with before/after diff |
| `delete_device_assurance_policy` | Delete with elicitation-guarded confirmation |

### Okta Python SDK Upgrade: v2.9.13 → v3.4.1

- Updates all tool files for SDK v3.4.1 conventions

