### PR TITLE
feat: support activate=false on create_user to enable STAGED users

### DIFF
--- a/src/okta_mcp_server/tools/users/users.py
+++ b/src/okta_mcp_server/tools/users/users.py
@@ -184,18 +184,22 @@ async def get_user(user_id: str, ctx: Context = None) -> list:
 
 
 @mcp.tool()
-async def create_user(profile: dict, ctx: Context = None) -> list:
+async def create_user(profile: dict, activate: bool = True, ctx: Context = None) -> list:
     """Create a user in the Okta organization.
 
     This tool creates a new user in the Okta organization with the provided profile.
 
     Parameters:
         profile (dict, required): The profile of the user to create.
+        activate (bool, optional): Whether to activate the user on creation.
+            Defaults to True (user lands in PROVISIONED, activation email sent).
+            Set to False to create the user in STAGED status (no activation email,
+            no provisioning workflows fire). Useful for pre-hire / bulk imports.
 
     Returns:
         List containing the created user details.
     """
-    logger.info("Creating new user in Okta organization")
+    logger.info(f"Creating new user in Okta organization (activate={activate})")
     logger.debug(f"User profile: email={profile.get('email', 'N/A')}, login={profile.get('login', 'N/A')}")
 
     manager = ctx.request_context.lifespan_context.okta_auth_manager
@@ -206,7 +210,7 @@ async def create_user(profile: dict, ctx: Context = None) -> list:
         user_data = {"profile": profile}
         logger.debug("Calling Okta API to create user")
 
-        user, _, err = await client.create_user(user_data)
+        user, _, err = await client.create_user(user_data, {"activate": str(activate).lower()})
 
         if err:
             logger.error(f"Okta API error while creating user: {err}")


### PR DESCRIPTION
## Summary

Adds an optional `activate: bool = True` parameter to the `create_user` tool. When set to `False`, the user is created in `STAGED` status (no activation email, no provisioning workflows fire). Default behavior is preserved.

Fixes #37

## Motivation

The Okta Users API supports `activate=false` via a query parameter, producing users in `STAGED` status. This is the standard starting state for:

- Pre-hire / future-dated employee imports
- M&A user migrations where activation is controlled centrally by HR/IT
- Bulk imports where you want to validate data before kicking off provisioning workflows

The current tool hardcoded the default (`activate=true`), firing activation emails immediately on create — blocking any use case that needs staged provisioning.

## Changes

- `src/okta_mcp_server/tools/users/users.py`: `create_user` now accepts `activate: bool = True` and passes `{"activate": str(activate).lower()}` as `query_params` to `client.create_user`. Docstring updated.

## Testing

Verified against a live Okta org by creating a user with `activate=false` via the underlying SDK call and confirming `user.status == UserStatus.STAGED`. Test user was cleaned up immediately after.