### PR TITLE
fix: require explicit confirmation for destructive operations

### DIFF
--- a/src/okta_mcp_server/utils/elicitation.py
+++ b/src/okta_mcp_server/utils/elicitation.py
@@ -101,15 +101,11 @@ async def elicit_or_fallback(
     """Request user confirmation via elicitation, falling back gracefully.
 
     If the client supports elicitation the user is shown a structured form.
-    If it does not (older client, no capability, exception), the behaviour
-    depends on ``auto_confirm_on_fallback``:
-
-    * ``False`` (default) — return the ``fallback_payload`` so the caller
-      can direct the LLM to a legacy two-tool confirmation flow (e.g.
-      ``confirm_delete_group``).
-    * ``True`` — treat the operation as confirmed and let the caller
-      proceed immediately.  This restores the pre-elicitation behaviour
-      for tools that never had a separate confirmation step.
+    If it does not (older client, no capability, exception), the operation
+    is NOT confirmed — ``confirmed`` is always ``False`` when elicitation
+    cannot be completed.  The ``fallback_payload`` is returned so the caller
+    can direct the LLM to a legacy two-tool confirmation flow (e.g.
+    ``confirm_delete_group``).
 
     Parameters
     ----------
@@ -121,22 +117,18 @@ async def elicit_or_fallback(
         A Pydantic ``BaseModel`` subclass describing the form fields.
     fallback_payload:
         Optional dict to return when elicitation is not available.  If
-        ``None``, a generic payload is used.  Ignored when
-        ``auto_confirm_on_fallback`` is ``True``.
+        ``None``, a generic payload is used.
     auto_confirm_on_fallback:
-        When ``True`` and elicitation is unavailable, the returned
-        outcome has ``confirmed=True`` so the tool can proceed without
-        user interaction (pre-elicitation behaviour).
+        Deprecated and ignored.  Previously allowed auto-confirmation
+        when elicitation was unavailable, but this was a security risk
+        for destructive operations.  Kept for API compatibility.
 
     Returns
     -------
     ElicitationOutcome
     """
     if not supports_elicitation(ctx):
-        if auto_confirm_on_fallback:
-            logger.info("Client does not support elicitation — auto-confirming (pre-elicitation behaviour)")
-            return ElicitationOutcome(confirmed=True, used_elicitation=False)
-        logger.info("Client does not support elicitation — using fallback")
+        logger.info("Client does not support elicitation — operation requires explicit confirmation")
         return ElicitationOutcome(
             confirmed=False,
             used_elicitation=False,
@@ -165,9 +157,6 @@ async def elicit_or_fallback(
             logger.info("Elicitation not supported by client (METHOD_NOT_FOUND)")
         else:
             logger.warning(f"MCP error during elicitation: {exc}")
-        if auto_confirm_on_fallback:
-            logger.info("Auto-confirming after MCP error (pre-elicitation behaviour)")
-            return ElicitationOutcome(confirmed=True, used_elicitation=False)
         return ElicitationOutcome(
             confirmed=False,
             used_elicitation=False,
@@ -178,9 +167,6 @@ async def elicit_or_fallback(
         )
     except Exception as exc:
         logger.warning(f"Elicitation failed ({type(exc).__name__}: {exc}) — using fallback")
-        if auto_confirm_on_fallback:
-            logger.info("Auto-confirming after elicitation failure (pre-elicitation behaviour)")
-            return ElicitationOutcome(confirmed=True, used_elicitation=False)
         return ElicitationOutcome(
             confirmed=False,
             used_elicitation=False,


### PR DESCRIPTION
# fix: require explicit confirmation for destructive operations

## Summary

This PR fixes a security vulnerability in `elicit_or_fallback()` where destructive
Okta operations could execute without user confirmation when the MCP client does not
support the elicitation protocol.

## Vulnerability

**File:** `src/okta_mcp_server/utils/elicitation.py`
**Function:** `elicit_or_fallback()`

The function accepted an `auto_confirm_on_fallback=True` parameter that, when set,
would return `confirmed=True` whenever elicitation was unavailable (unsupported client,
`McpError`, or any other exception). This effectively bypassed the confirmation
requirement for all destructive operations that used this flag.

### Affected operations (8 total)

| Tool | File | Operation |
|------|------|-----------|
| `deactivate_user` | `users.py` | Deactivate an Okta user |
| `delete_deactivated_user` | `users.py` | Permanently delete a user |
| `deactivate_application` | `applications.py` | Deactivate an application |
| `deactivate_lifecycle_policy` | `policies.py` | Deactivate a lifecycle policy |
| `delete_lifecycle_policy` | `policies.py` | Delete a lifecycle policy |
| `deactivate_access_policy` | `policies.py` | Deactivate an access policy |
| `delete_access_policy` | `policies.py` | Delete an access policy |
| `delete_device_assurance` | `device_assurance.py` | Delete a device assurance policy |

### Attack scenario

An MCP client that does not support elicitation (or one that throws an exception
during the elicitation call) would cause every destructive operation above to proceed
immediately without any user confirmation. This violates the principle of least
privilege and could lead to accidental or malicious deletion of users, applications,
and policies.

## Fix

When elicitation is not supported or throws an exception, the fallback now
**always** returns `confirmed=False`, requiring the caller to use the legacy
two-tool confirmation flow. The `auto_confirm_on_fallback` parameter is retained
for API compatibility but is now ignored and marked as deprecated.

### Changes

- **`src/okta_mcp_server/utils/elicitation.py`**: Removed three code paths that
  returned `confirmed=True` when `auto_confirm_on_fallback=True`. Updated docstring
  to document the new behavior and deprecate the parameter.

## CWE References

- **CWE-862: Missing Authorization** -- The original code skipped the authorization
  (confirmation) step when elicitation was unavailable, allowing destructive
  operations without the required user consent.
- **CWE-306: Missing Authentication for Critical Function** -- Destructive operations
  that require explicit user confirmation could proceed without any authentication
  of user intent when the elicitation protocol was not available.

## Test plan

1. Verify that with an elicitation-capable client, the confirmation dialog is shown
   and the operation only proceeds when the user clicks "Confirm".
2. Verify that with a client that does NOT support elicitation, the fallback returns
   `confirmed=False` and a `confirmation_required` payload.
3. Verify that when the elicitation call throws an exception, the fallback returns
   `confirmed=False`.
4. Run the existing elicitation test suite to ensure no regressions:
   `pytest tests/elicitation/`