### PR TITLE
fix: exit cleanly when started without a stdio client

### DIFF
--- a/src/okta_mcp_server/__init__.py
+++ b/src/okta_mcp_server/__init__.py
@@ -5,11 +5,13 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-import asyncio
-
 from . import server
 
 
 def main():
     """Run the server"""
-    asyncio.run(server.main())
+    # server.main() is synchronous and runs the MCP event loop itself via
+    # mcp.run(), so it must be called directly. Wrapping it in asyncio.run()
+    # crashed on startup with "a coroutine was expected, got None" whenever
+    # mcp.run() returned (e.g. when launched without a stdio client attached).
+    server.main()

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,30 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for the package entrypoint (okta_mcp_server.main)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import okta_mcp_server
+
+
+def test_main_calls_server_main_once():
+    with patch("okta_mcp_server.server.main") as mock_server_main:
+        okta_mcp_server.main()
+        mock_server_main.assert_called_once_with()
+
+
+def test_main_does_not_crash_when_server_main_returns_none():
+    """server.main() returns None once mcp.run() exits; the entrypoint must not raise.
+
+    The previous asyncio.run(server.main()) wrapper raised
+    'ValueError: a coroutine was expected, got None' in this case.
+    """
+    with patch("okta_mcp_server.server.main", return_value=None):
+        okta_mcp_server.main()


### PR DESCRIPTION
The console entrypoint wrapped the synchronous `server.main()` in `asyncio.run()`. `server.main()` ends in the blocking `mcp.run()` and returns `None`, so `asyncio.run(None)` raised `ValueError: a coroutine was expected, got None` whenever the server was launched without a stdio client attached. Calls the already-synchronous `main()` directly.

Tests: `tests/test_entrypoint.py`.