### PR TITLE
docs: clarify that .read and .manage scopes are independent

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,8 +697,8 @@ Then restart your MCP client so the server picks up the new scope list.
 > [!TIP]
 > Start with the minimum set of scopes your use-case requires. For example, if you only need to read users and brands, use `okta.users.read okta.brands.read`. Adding `okta.*.manage` scopes enables write operations — only grant those if needed.
 
-> [!NOTE]
-> Scopes follow the pattern `okta.<resource>.read` for read-only access and `okta.<resource>.manage` for full read+write access. You do **not** need both — `okta.users.manage` implicitly enables all read operations on users.
+> [!IMPORTANT]
+> `.read` and `.manage` are independent — **`.manage` does not imply `.read`**. Each tool requires exactly one scope (see the table above): read and list tools need `okta.<resource>.read`, write tools need `okta.<resource>.manage`. If you grant only `okta.apps.manage`, the write tools load but `list_applications` and `get_application` stay disabled because they require `okta.apps.read`. To get both read and write tools for a resource, include **both** scopes, e.g. `okta.apps.read okta.apps.manage`.
 
 ## �🔐 Authentication
 

--- a/src/okta_mcp_server/utils/scope_registry.py
+++ b/src/okta_mcp_server/utils/scope_registry.py
@@ -16,7 +16,8 @@ tool name to the minimum OAuth 2.0 scope required to call it.  It is used by:
 Scope naming convention:
     ``okta.<resource>.read``    — GET operations (read-only).
     ``okta.<resource>.manage``  — POST / PUT / DELETE operations (write).
-    A token with ``*.manage`` implicitly covers ``*.read`` for the same resource.
+    These are independent: a token with ``*.manage`` does NOT grant ``*.read``.
+    To use both read and write tools for a resource, configure BOTH scopes.
 
 Reference: https://developer.okta.com/docs/api/oauth2
 """


### PR DESCRIPTION
The README and the `scope_registry` docstring stated that a `.manage` scope implicitly covers `.read`. The server gates each tool on exactly one scope, so granting only `okta.apps.manage` leaves `list_applications`/`get_application` disabled. Corrects both to state the scopes are independent and that read and write access require configuring both. Documentation only.