### PR TITLE
feat: add application provisioning (SCIM) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,12 @@ The Okta MCP Server provides the following tools for LLMs to interact with your 
 | `delete_application`          | Delete an application (prompts for confirmation)  | - `Delete the old legacy application` <br> - `Remove the unused test application` <br> - `Clean up deprecated integrations`                                   |
 | `activate_application`        | Activate an application                           | - `Activate the new HR application` <br> - `Enable the Salesforce integration` <br> - `Turn on the mobile app for users`                                      |
 | `deactivate_application`      | Deactivate an application (prompts for confirmation) | - `Deactivate the legacy CRM application` <br> - `Temporarily disable the mobile app` <br> - `Turn off access to the test environment`                        |
+| `get_app_provisioning_connection` | Read an app's SCIM provisioning connection (base URL, auth scheme, status) | - `What SCIM endpoint is this app provisioning to?` <br> - `Is provisioning enabled for the HR app?`                                                         |
+| `set_app_provisioning_connection` | Point an app at an external SCIM endpoint (base URL + bearer token) | - `Configure SCIM provisioning for this app to https://scim.vendor.com/v2` <br> - `Set up directory sync to our SCIM endpoint`                               |
+| `activate_app_provisioning_connection` | Activate an app's provisioning connection | - `Enable provisioning for the HR app`                                                                                                                       |
+| `deactivate_app_provisioning_connection` | Deactivate an app's provisioning connection | - `Turn off provisioning for the HR app`                                                                                                                     |
+| `list_app_features`           | List an app's provisioning features and capabilities | - `What provisioning actions are enabled for this app?` <br> - `Show the SCIM capabilities for the HR app`                                                   |
+| `update_app_feature`          | Configure a provisioning feature's actions (create/update/deactivate users, push groups) | - `Enable create and deactivate users for this app's provisioning` <br> - `Turn on user provisioning push for the HR app`                                    |
 
 ### Policies
 
@@ -658,8 +664,8 @@ The Okta MCP Server uses a **scope-based tool loading** mechanism to ensure that
 | `okta.users.manage` | `create_user`, `update_user`, `deactivate_user`, `delete_deactivated_user` |
 | `okta.groups.read` | `list_groups`, `get_group`, `list_group_users`, `list_group_apps` |
 | `okta.groups.manage` | `create_group`, `update_group`, `delete_group`, `add_user_to_group`, `remove_user_from_group` |
-| `okta.apps.read` | `list_applications`, `get_application` |
-| `okta.apps.manage` | `create_application`, `update_application`, `delete_application`, `activate_application`, `deactivate_application` |
+| `okta.apps.read` | `list_applications`, `get_application`, `get_app_provisioning_connection`, `list_app_features` |
+| `okta.apps.manage` | `create_application`, `update_application`, `delete_application`, `activate_application`, `deactivate_application`, `set_app_provisioning_connection`, `activate_app_provisioning_connection`, `deactivate_app_provisioning_connection`, `update_app_feature` |
 | `okta.policies.read` | `list_policies`, `get_policy`, `list_policy_rules`, `get_policy_rule` |
 | `okta.policies.manage` | `create_policy`, `update_policy`, `delete_policy`, `activate_policy`, `deactivate_policy`, `create_policy_rule`, `update_policy_rule`, `delete_policy_rule`, `activate_policy_rule`, `deactivate_policy_rule` |
 | `okta.deviceAssurance.read` | `list_device_assurance_policies`, `get_device_assurance_policy` |

--- a/src/okta_mcp_server/tools/applications/applications.py
+++ b/src/okta_mcp_server/tools/applications/applications.py
@@ -444,3 +444,279 @@ async def deactivate_application(ctx: Context, app_id: str) -> list:
     except Exception as e:
         logger.error(f"Exception while deactivating application {app_id}: {type(e).__name__}: {e}")
         return [f"Exception: {e}"]
+
+
+# ---------------------------------------------------------------------------
+# Provisioning (outbound SCIM / directory sync)
+# ---------------------------------------------------------------------------
+
+
+def _provisioning_unsupported_error(connection: Dict[str, Any], app_id: str) -> Optional[Dict[str, Any]]:
+    """Detect Okta's "provisioning not supported" sentinel.
+
+    When an app does not support outbound provisioning, Okta returns HTTP 200
+    (no error) with the connection ``status`` and ``profile.authScheme`` both set
+    to ``UNKNOWN`` instead of a 4xx. Without this guard the tool returns that body
+    as if the connection were configured. Returns an error dict when the sentinel
+    is detected, otherwise None.
+    """
+    status = connection.get("status")
+    auth_scheme = (connection.get("profile") or {}).get("authScheme")
+    if status == "UNKNOWN" and auth_scheme == "UNKNOWN":
+        return {
+            "error": (
+                f"Provisioning is not enabled or supported on application {app_id} "
+                f"(Okta returned status=UNKNOWN). Outbound SCIM provisioning only works "
+                f"on a provisioning-capable app; a plain custom SAML/OIDC app cannot be "
+                f"pointed at a SCIM endpoint."
+            )
+        }
+    return None
+
+
+@mcp.tool()
+@require_scopes("okta.apps.read")
+@validate_ids("app_id", error_return_type="dict")
+async def get_app_provisioning_connection(ctx: Context, app_id: str) -> Any:
+    """Get the provisioning (SCIM) connection configuration for an application.
+
+    Returns the connection's base URL, auth scheme, and status (the bearer token
+    itself is never returned by Okta).
+
+    Parameters:
+        app_id (str, required): The ID of the application
+
+    Returns:
+        Dict with the provisioning connection details, or error information.
+    """
+    logger.info(f"Getting provisioning connection for application: {app_id}")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        connection, _, err = await client.get_default_provisioning_connection_for_application(app_id)
+
+        if err:
+            logger.error(f"Okta API error while getting provisioning connection for {app_id}: {err}")
+            return {"error": str(err)}
+
+        if not connection:
+            return {}
+        conn_dict = connection.to_dict()
+        unsupported = _provisioning_unsupported_error(conn_dict, app_id)
+        if unsupported:
+            return unsupported
+
+        logger.info(f"Successfully retrieved provisioning connection for application: {app_id}")
+        return conn_dict
+    except Exception as e:
+        logger.error(f"Exception while getting provisioning connection for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@require_scopes("okta.apps.manage")
+@validate_ids("app_id", error_return_type="dict")
+async def set_app_provisioning_connection(
+    ctx: Context, app_id: str, base_url: str, token: str, activate: bool = True
+) -> Any:
+    """Configure the outbound SCIM provisioning connection for an application.
+
+    Points the application at an external SCIM endpoint using bearer-token (HEADER)
+    authentication, which is the common directory-sync setup.
+
+    Parameters:
+        app_id (str, required): The ID of the application
+        base_url (str, required): The SCIM connector base URL of the external endpoint
+        token (str, required): The bearer token used to authenticate to the SCIM endpoint
+        activate (bool, optional): Activate the provisioning connection. Defaults to True.
+
+    Returns:
+        Dict with the updated provisioning connection details, or error information.
+    """
+    logger.info(f"Setting provisioning connection for application {app_id} (base_url={base_url})")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        # Build the request via from_dict so the oneOf union binds to the
+        # token-auth variant; the plain constructor would drop base_url/token.
+        request = okta_models.UpdateDefaultProvisioningConnectionForApplicationRequest.from_dict(
+            {"baseUrl": base_url, "profile": {"authScheme": "TOKEN", "token": token}}
+        )
+        logger.debug(f"Calling Okta API to set provisioning connection for {app_id} (activate={activate})")
+
+        connection, _, err = await client.update_default_provisioning_connection_for_application(
+            app_id, request, activate
+        )
+
+        if err:
+            logger.error(f"Okta API error while setting provisioning connection for {app_id}: {err}")
+            return {"error": str(err)}
+
+        if not connection:
+            return {}
+        conn_dict = connection.to_dict()
+        unsupported = _provisioning_unsupported_error(conn_dict, app_id)
+        if unsupported:
+            logger.warning(f"Provisioning is not supported on application {app_id} (status=UNKNOWN)")
+            return unsupported
+
+        logger.info(f"Successfully set provisioning connection for application: {app_id}")
+        return conn_dict
+    except Exception as e:
+        logger.error(f"Exception while setting provisioning connection for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@require_scopes("okta.apps.manage")
+@validate_ids("app_id", error_return_type="dict")
+async def activate_app_provisioning_connection(ctx: Context, app_id: str) -> Any:
+    """Activate the provisioning (SCIM) connection for an application.
+
+    Parameters:
+        app_id (str, required): The ID of the application
+
+    Returns:
+        Dict with the connection status or a success message, or error information.
+    """
+    logger.info(f"Activating provisioning connection for application: {app_id}")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        connection, _, err = await client.activate_default_provisioning_connection_for_application(app_id)
+
+        if err:
+            logger.error(f"Okta API error while activating provisioning connection for {app_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully activated provisioning connection for application: {app_id}")
+        if connection:
+            return connection.to_dict()
+        return {"message": f"Provisioning connection activated for application {app_id}"}
+    except Exception as e:
+        logger.error(f"Exception while activating provisioning connection for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@require_scopes("okta.apps.manage")
+@validate_ids("app_id", error_return_type="dict")
+async def deactivate_app_provisioning_connection(ctx: Context, app_id: str) -> Any:
+    """Deactivate the provisioning (SCIM) connection for an application.
+
+    Parameters:
+        app_id (str, required): The ID of the application
+
+    Returns:
+        Dict with the connection status or a success message, or error information.
+    """
+    logger.info(f"Deactivating provisioning connection for application: {app_id}")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        connection, _, err = await client.deactivate_default_provisioning_connection_for_application(app_id)
+
+        if err:
+            logger.error(f"Okta API error while deactivating provisioning connection for {app_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully deactivated provisioning connection for application: {app_id}")
+        if connection:
+            return connection.to_dict()
+        return {"message": f"Provisioning connection deactivated for application {app_id}"}
+    except Exception as e:
+        logger.error(f"Exception while deactivating provisioning connection for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@require_scopes("okta.apps.read")
+@validate_ids("app_id", error_return_type="dict")
+async def list_app_features(ctx: Context, app_id: str) -> Any:
+    """List the provisioning features and their capabilities for an application.
+
+    Features include ``USER_PROVISIONING`` (outbound to a SCIM target) and
+    ``INBOUND_PROVISIONING``. Each entry reports its status and configured
+    capabilities (create / update / deactivate users, group push).
+
+    Parameters:
+        app_id (str, required): The ID of the application
+
+    Returns:
+        Dict with a ``features`` list, or error information.
+    """
+    logger.info(f"Listing features for application: {app_id}")
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        features, _, err = await client.list_features_for_application(app_id)
+
+        if err:
+            logger.error(f"Okta API error while listing features for {app_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully listed features for application: {app_id}")
+        return {"features": [f.to_dict() for f in features] if features else []}
+    except Exception as e:
+        logger.error(f"Exception while listing features for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}
+
+
+@mcp.tool()
+@require_scopes("okta.apps.manage")
+@validate_ids("app_id", error_return_type="dict")
+async def update_app_feature(ctx: Context, app_id: str, feature_name: str, capabilities: Dict[str, Any]) -> Any:
+    """Configure a provisioning feature's capabilities for an application.
+
+    Use this to enable the provisioning actions for outbound SCIM directory sync.
+
+    Parameters:
+        app_id (str, required): The ID of the application
+        feature_name (str, required): The feature to configure — ``USER_PROVISIONING``
+            or ``INBOUND_PROVISIONING``.
+        capabilities (dict, required): The capabilities object, e.g.
+            ``{"create": {"lifecycleCreate": {"status": "ENABLED"}},
+            "update": {"profile": {"status": "ENABLED"},
+            "lifecycleDeactivate": {"status": "ENABLED"}}}``.
+
+    Returns:
+        Dict with the updated feature, or error information.
+    """
+    logger.info(f"Updating feature '{feature_name}' for application: {app_id}")
+
+    try:
+        feature_type = okta_models.ApplicationFeatureType(feature_name)
+    except ValueError:
+        valid = ", ".join(e.value for e in okta_models.ApplicationFeatureType)
+        return {"error": f"Invalid feature_name '{feature_name}'. Must be one of: {valid}."}
+
+    manager = ctx.request_context.lifespan_context.okta_auth_manager
+
+    try:
+        client = await get_okta_client(manager)
+        # from_dict binds the oneOf capabilities union; the plain constructor would
+        # serialize an empty body and silently no-op the configuration.
+        request = okta_models.UpdateFeatureForApplicationRequest.from_dict(capabilities)
+        logger.debug(f"Calling Okta API to update feature '{feature_name}' for {app_id}")
+
+        feature, _, err = await client.update_feature_for_application(app_id, feature_type, request)
+
+        if err:
+            logger.error(f"Okta API error while updating feature '{feature_name}' for {app_id}: {err}")
+            return {"error": str(err)}
+
+        logger.info(f"Successfully updated feature '{feature_name}' for application: {app_id}")
+        return feature.to_dict() if feature else {}
+    except Exception as e:
+        logger.error(f"Exception while updating feature '{feature_name}' for {app_id}: {type(e).__name__}: {e}")
+        return {"error": str(e)}

--- a/src/okta_mcp_server/utils/scope_registry.py
+++ b/src/okta_mcp_server/utils/scope_registry.py
@@ -59,6 +59,12 @@ TOOL_SCOPE_REGISTRY: dict[str, str] = {
     "confirm_delete_application":           "okta.apps.manage",
     "activate_application":                 "okta.apps.manage",
     "deactivate_application":               "okta.apps.manage",
+    "get_app_provisioning_connection":      "okta.apps.read",
+    "set_app_provisioning_connection":      "okta.apps.manage",
+    "activate_app_provisioning_connection": "okta.apps.manage",
+    "deactivate_app_provisioning_connection": "okta.apps.manage",
+    "list_app_features":                    "okta.apps.read",
+    "update_app_feature":                   "okta.apps.manage",
     # ------------------------------------------------------------------
     # Policies  (src/okta_mcp_server/tools/policies/policies.py)
     # ------------------------------------------------------------------

--- a/tests/test_app_provisioning.py
+++ b/tests/test_app_provisioning.py
@@ -1,0 +1,228 @@
+# The Okta software accompanied by this notice is provided pursuant to the following terms:
+# Copyright © 2026-Present, Okta, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and limitations under the License.
+
+"""Tests for application provisioning (outbound SCIM / directory sync) tools."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from okta.models import (
+    ApplicationFeatureType,
+    UpdateDefaultProvisioningConnectionForApplicationRequest,
+    UpdateFeatureForApplicationRequest,
+)
+
+from okta_mcp_server.tools.applications.applications import (
+    activate_app_provisioning_connection,
+    deactivate_app_provisioning_connection,
+    get_app_provisioning_connection,
+    list_app_features,
+    set_app_provisioning_connection,
+    update_app_feature,
+)
+
+
+APP_ID = "0oaSCIMAPP000001"
+BASE_URL = "https://scim.vendor.com/scim/v2"
+TOKEN = "scim-bearer-secret"
+
+
+def _make_ctx():
+    from tests.conftest import FakeLifespanContext, FakeOktaAuthManager
+
+    request_context = MagicMock()
+    request_context.lifespan_context = FakeLifespanContext(
+        okta_auth_manager=FakeOktaAuthManager()
+    )
+    ctx = MagicMock()
+    ctx.request_context = request_context
+    return ctx
+
+
+def _model(d):
+    obj = MagicMock()
+    obj.to_dict.return_value = d
+    return obj
+
+
+_UNKNOWN_BODY = {"profile": {"authScheme": "UNKNOWN"}, "status": "UNKNOWN"}
+
+
+class TestGetProvisioningConnection:
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_returns_connection_dict(self, mock_get_client):
+        conn = _model({"baseUrl": BASE_URL, "authScheme": "TOKEN", "status": "ENABLED"})
+        client = AsyncMock()
+        client.get_default_provisioning_connection_for_application.return_value = (conn, None, None)
+        mock_get_client.return_value = client
+
+        result = await get_app_provisioning_connection(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert result == {"baseUrl": BASE_URL, "authScheme": "TOKEN", "status": "ENABLED"}
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_unknown_status_surfaces_unsupported_error(self, mock_get_client):
+        client = AsyncMock()
+        client.get_default_provisioning_connection_for_application.return_value = (_model(_UNKNOWN_BODY), None, None)
+        mock_get_client.return_value = client
+
+        result = await get_app_provisioning_connection(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert "error" in result
+        assert "not enabled or supported" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_api_error_is_returned(self, mock_get_client):
+        client = AsyncMock()
+        client.get_default_provisioning_connection_for_application.return_value = (None, None, "404 not found")
+        mock_get_client.return_value = client
+
+        result = await get_app_provisioning_connection(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert result == {"error": "404 not found"}
+
+
+class TestSetProvisioningConnection:
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_unknown_status_surfaces_unsupported_error(self, mock_get_client):
+        # Okta returns 200 + status/authScheme UNKNOWN (no error) on an app that
+        # doesn't support provisioning — must surface a clear error, not "success".
+        client = AsyncMock()
+        client.update_default_provisioning_connection_for_application.return_value = (_model(_UNKNOWN_BODY), None, None)
+        mock_get_client.return_value = client
+
+        result = await set_app_provisioning_connection(
+            ctx=_make_ctx(), app_id=APP_ID, base_url=BASE_URL, token=TOKEN
+        )
+
+        assert "error" in result
+        assert "not enabled or supported" in result["error"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_sends_token_request_with_base_url_and_token(self, mock_get_client):
+        conn = _model({"baseUrl": BASE_URL, "authScheme": "TOKEN", "status": "ENABLED"})
+        client = AsyncMock()
+        client.update_default_provisioning_connection_for_application.return_value = (conn, None, None)
+        mock_get_client.return_value = client
+
+        result = await set_app_provisioning_connection(
+            ctx=_make_ctx(), app_id=APP_ID, base_url=BASE_URL, token=TOKEN
+        )
+
+        assert result == {"baseUrl": BASE_URL, "authScheme": "TOKEN", "status": "ENABLED"}
+
+        call_args = client.update_default_provisioning_connection_for_application.call_args[0]
+        assert call_args[0] == APP_ID
+        request = call_args[1]
+        assert isinstance(request, UpdateDefaultProvisioningConnectionForApplicationRequest)
+        # The oneOf union must have bound to the token variant and carry the real
+        # base URL + token (the regression that bit attribute statements in #9).
+        assert request.to_dict() == {
+            "baseUrl": BASE_URL,
+            "profile": {"authScheme": "TOKEN", "token": TOKEN},
+        }
+        assert call_args[2] is True  # activate defaults to True
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_activate_false_is_forwarded(self, mock_get_client):
+        client = AsyncMock()
+        client.update_default_provisioning_connection_for_application.return_value = (_model({}), None, None)
+        mock_get_client.return_value = client
+
+        await set_app_provisioning_connection(
+            ctx=_make_ctx(), app_id=APP_ID, base_url=BASE_URL, token=TOKEN, activate=False
+        )
+
+        assert client.update_default_provisioning_connection_for_application.call_args[0][2] is False
+
+
+class TestProvisioningConnectionLifecycle:
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_activate_empty_body_returns_message(self, mock_get_client):
+        client = AsyncMock()
+        client.activate_default_provisioning_connection_for_application.return_value = (None, MagicMock(), None)
+        mock_get_client.return_value = client
+
+        result = await activate_app_provisioning_connection(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert "message" in result
+        assert APP_ID in result["message"]
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_deactivate_error_is_returned(self, mock_get_client):
+        client = AsyncMock()
+        client.deactivate_default_provisioning_connection_for_application.return_value = (None, None, "403 forbidden")
+        mock_get_client.return_value = client
+
+        result = await deactivate_app_provisioning_connection(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert result == {"error": "403 forbidden"}
+
+
+class TestListAppFeatures:
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_returns_feature_dicts(self, mock_get_client):
+        f1 = _model({"name": "USER_PROVISIONING", "status": "ENABLED"})
+        client = AsyncMock()
+        client.list_features_for_application.return_value = ([f1], None, None)
+        mock_get_client.return_value = client
+
+        result = await list_app_features(ctx=_make_ctx(), app_id=APP_ID)
+
+        assert result == {"features": [{"name": "USER_PROVISIONING", "status": "ENABLED"}]}
+
+
+class TestUpdateAppFeature:
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_sends_capabilities_and_feature_type(self, mock_get_client):
+        feature = _model({"name": "USER_PROVISIONING", "status": "ENABLED"})
+        client = AsyncMock()
+        client.update_feature_for_application.return_value = (feature, None, None)
+        mock_get_client.return_value = client
+
+        caps = {
+            "create": {"lifecycleCreate": {"status": "ENABLED"}},
+            "update": {"lifecycleDeactivate": {"status": "ENABLED"}, "profile": {"status": "ENABLED"}},
+        }
+        result = await update_app_feature(
+            ctx=_make_ctx(), app_id=APP_ID, feature_name="USER_PROVISIONING", capabilities=caps
+        )
+
+        assert result == {"name": "USER_PROVISIONING", "status": "ENABLED"}
+
+        call_args = client.update_feature_for_application.call_args[0]
+        assert call_args[0] == APP_ID
+        assert call_args[1] == ApplicationFeatureType.USER_PROVISIONING
+        request = call_args[2]
+        assert isinstance(request, UpdateFeatureForApplicationRequest)
+        assert request.to_dict() == caps
+
+    @pytest.mark.asyncio
+    @patch("okta_mcp_server.tools.applications.applications.get_okta_client")
+    async def test_invalid_feature_name_rejected_before_api_call(self, mock_get_client):
+        client = AsyncMock()
+        mock_get_client.return_value = client
+
+        result = await update_app_feature(
+            ctx=_make_ctx(), app_id=APP_ID, feature_name="BOGUS", capabilities={}
+        )
+
+        assert "error" in result
+        assert "Invalid feature_name" in result["error"]
+        client.update_feature_for_application.assert_not_called()


### PR DESCRIPTION
There was no way to configure outbound SCIM provisioning (directory sync) on an application. Adds connection tools (`get`/`set`/`activate`/`deactivate` — base URL + bearer token, TOKEN auth) and feature tools (`list_app_features`/`update_app_feature`). The request bodies are SDK oneOf unions built via `from_dict` so the base URL, token, and capabilities actually serialize. On an app that does not support provisioning, Okta returns HTTP 200 with `status`/`authScheme` = `UNKNOWN` and no error; the connection tools detect that sentinel and return a clear error.

Tests: `tests/test_app_provisioning.py`.