### PR TITLE
chore(release): prepare okta-mcp-server v1.1.1 for PyPI publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.1.2
+
+### Features
+- PyPI Release changes
+
 ## v1.1.1
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![Okta MCP Server](assets/thumbnail.png)
+![Okta MCP Server](https://raw.githubusercontent.com/okta/okta-mcp-server/main/assets/thumbnail.png)
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-%3E%3D3.8-brightgreen.svg)](https://python.org/)
@@ -873,7 +873,7 @@ This project is licensed under the Apache 2.0 license. See the [LICENSE](LICENSE
 
 <p align="center">
   <picture>
-    <img alt="Okta Logo" src="assets/logo.png" width="150">
+    <img alt="Okta Logo" src="https://raw.githubusercontent.com/okta/okta-mcp-server/main/assets/logo.png" width="150">
   </picture>
 </p>
 <p align="center">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "okta-mcp-server"
-version = "1.1.1"
-description = "Okta MCP Server"
+version = "1.1.2"
+description = "The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA)."
 readme = "README.md"
 requires-python = ">=3.13"
 license = "Apache-2.0"
@@ -17,9 +17,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Systems Administration :: Authentication/Directory",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,29 +4,80 @@ version = "1.1.1"
 description = "Okta MCP Server"
 readme = "README.md"
 requires-python = ">=3.13"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE.md"]
+authors = [
+    { name = "Okta, Inc." },
+]
+maintainers = [
+    { name = "Developer Community Products", email = "developer-community-products@okta.com" },
+]
+keywords = ["okta", "mcp", "model-context-protocol", "llm", "ai-agents", "identity", "iam"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: System :: Systems Administration :: Authentication/Directory",
+    "Typing :: Typed",
+]
 dependencies = [
     "loguru>=0.7.3",
     "mcp[cli]>=1.26.0,<2.0.0",
     "okta==3.4.1",
     "requests>=2.32.4",
-    "ruff>=0.11.13",
     "keyring>=25.6.0",
     "keyrings.alt>=5.0.0",
     "flatdict>=4.1.0",
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/okta_mcp_server"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+  "src/okta_mcp_server",
+  "README.md",
+  "LICENSE",
+  "NOTICE.md",
+  "CHANGELOG.md",
+  "SECURITY.md",
+  "pyproject.toml",
+]
+exclude = [
+  "**/__pycache__",
+  "**/*.pyc",
+  "tests/**",
+  ".vscode/**",
+  ".idea/**",
+  "assets/**",
+  "docs/**",
+  "Dockerfile",
+  "docker-compose.yml",
+  ".env*",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
+    "ruff>=0.11.13",
 ]
+
+[project.urls]
+Homepage      = "https://github.com/okta/okta-mcp-server"
+Documentation = "https://github.com/okta/okta-mcp-server#readme"
+Repository    = "https://github.com/okta/okta-mcp-server"
+Issues        = "https://github.com/okta/okta-mcp-server/issues"
+Changelog     = "https://github.com/okta/okta-mcp-server/blob/main/CHANGELOG.md"
 
 [project.scripts]
 okta-mcp-server = "okta_mcp_server:main"

--- a/uv.lock
+++ b/uv.lock
@@ -619,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "okta-mcp-server"
-version = "0.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "flatdict" },
@@ -629,13 +629,13 @@ dependencies = [
     { name = "mcp", extra = ["cli"] },
     { name = "okta" },
     { name = "requests" },
-    { name = "ruff" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -647,13 +647,13 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0,<2.0.0" },
     { name = "okta", specifier = "==3.4.1" },
     { name = "requests", specifier = ">=2.32.4" },
-    { name = "ruff", specifier = ">=0.11.13" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.11.13" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prepares `okta-mcp-server` for its first publication on [PyPI](https://pypi.org/) as version **1.1.1**. This is a packaging-only change: no source code under `src/` is modified, no tests change, and no runtime behaviour changes for existing users who install from source via `uv sync`.

After this PR is merged and tagged `v1.1.1`, the project can be installed by end users with:

```sh
pip install okta-mcp-server
# or
uvx okta-mcp-server
```

## Motivation

The current `pyproject.toml` carries the minimum metadata required to build a wheel locally, but is not ready for PyPI:

- No license / authors / classifiers / keywords / project URLs, so the PyPI project page would render almost empty and the package would not surface in PyPI search.
- `ruff` (a development tool) is declared as a runtime dependency, which would force every end user to install it.
- The sdist had no explicit `include` / `exclude` rules, so a `uv build` could pull in IDE folders, `.env*` files, `tests/`, `assets/`, `docs/`, and `Dockerfile` into the published tarball.
- The README's hero image and footer logo reference relative paths (`assets/thumbnail.png`, `assets/logo.png`) which PyPI does not resolve, so both images would appear broken on the project page.

## Changes

### `pyproject.toml`

**Version & description**

- `version`: `1.1.0` → `1.1.1`.
- `description`: replaced the placeholder `"Okta MCP Server"` with a one-line sentence describing what the package does.

**Licensing (PEP 639)**

- Added `license = "Apache-2.0"` (SPDX expression).
- Added `license-files = ["LICENSE", "NOTICE.md"]` so both files are packaged into `dist-info/licenses/` in the wheel and surfaced on PyPI.
- Bumped the build backend requirement to `hatchling>=1.27` (the first hatchling release that fully supports PEP 639 license fields).

**PyPI sidebar metadata**

- Added `authors` (`Okta, Inc.`) and `maintainers` (`developer-community-products@okta.com`).
- Added `keywords`: `okta`, `mcp`, `model-context-protocol`, `llm`, `ai-agents`, `identity`, `iam`.
- Added `classifiers`: `Development Status :: 4 - Beta`, `Intended Audience :: Developers` / `System Administrators`, `License :: OSI Approved :: Apache Software License`, `Operating System :: OS Independent`, `Programming Language :: Python :: 3` / `Programming Language :: Python :: 3.13`, `Topic :: Software Development :: Libraries :: Python Modules`, `Topic :: System :: Systems Administration :: Authentication/Directory`, and `Typing :: Typed`.
- Added `[project.urls]` for `Homepage`, `Documentation`, `Repository`, `Issues`, and `Changelog`.

**Dependencies**

- Moved `ruff>=0.11.13` out of `[project].dependencies` and into `[dependency-groups].dev`. Runtime install is now lighter and does not pull in lint tooling.

**Source distribution layout**

Added `[tool.hatch.build.targets.sdist]` with explicit `include` and `exclude` blocks:

- **Include**: `src/okta_mcp_server`, `README.md`, `LICENSE`, `NOTICE.md`, `CHANGELOG.md`, `SECURITY.md`, `pyproject.toml`.
- **Exclude**: `**/__pycache__`, `**/*.pyc`, `tests/**`, `.vscode/**`, `.idea/**`, `assets/**`, `docs/**`, `Dockerfile`, `docker-compose.yml`, `.env*`.

This keeps the sdist focused on what end users and PyPI need and prevents local-only artefacts from leaking into the published tarball.

### `README.md`

- Rewrote `assets/thumbnail.png` → absolute `https://raw.githubusercontent.com/okta/okta-mcp-server/main/assets/thumbnail.png` so the hero image renders on the PyPI project page.
- Same rewrite for the footer `assets/logo.png` reference.

### `CHANGELOG.md`

- Added a new `## v1.1.1` section with a `### Features` entry noting the PyPI publication.

## Verification

Local build and validation:

```sh
$ rm -rf dist build src/*.egg-info
$ uv build
$ ls dist/
okta_mcp_server-1.1.1-py3-none-any.whl
okta_mcp_server-1.1.1.tar.gz

$ uvx twine check dist/*
Checking dist/okta_mcp_server-1.1.1-py3-none-any.whl: PASSED
Checking dist/okta_mcp_server-1.1.1.tar.gz: PASSED
```

Wheel contents inspected with `unzip -l`:

- All `.py` files under `src/okta_mcp_server/` are present.
- `LICENSE` and `NOTICE.md` ship under `okta_mcp_server-1.1.1.dist-info/licenses/`.
- No `tests/`, `assets/`, `docs/`, `.env*`, `.vscode/`, or `.idea/`
  entries.

Fresh-venv smoke install:

```sh
$ uv venv /tmp/pypi-test && source /tmp/pypi-test/bin/activate
$ uv pip install dist/okta_mcp_server-1.1.1-py3-none-any.whl
$ which okta-mcp-server /tmp/pypi-test/bin/okta-mcp-server
$ okta-mcp-server --help  # entry point loads, server starts
```