### PR TITLE
fix: apply permissive model workaround to prevent pydantic validation errors on App Catalog SAML apps (closes #48)

### DIFF
--- a/src/okta_mcp_server/tools/system_logs/system_logs.py
+++ b/src/okta_mcp_server/tools/system_logs/system_logs.py
@@ -33,6 +33,23 @@ try:
 except Exception as _patch_err:
     logger.warning(f"Could not apply userBehaviors workaround: {_patch_err}")
 
+# Workaround for SDK model strictness: allow extra fields and make all fields optional in
+# Application models to prevent a single bad record from poisoning the entire response.
+try:
+    import pydantic
+    from okta.models.application import Application
+
+    # Make Application model permissive: allow extra fields and make all fields optional.
+    for field_name, field_info in Application.model_fields.items():
+        if field_info.is_required():
+            field_info.default = None
+            field_info.annotation = _typing.Optional[field_info.annotation]
+    Application.model_config['extra'] = 'allow'
+    Application.model_rebuild(force=True)
+    logger.debug("Applied permissive config for Application model (workaround for strict validation)")
+except Exception as _patch_err:
+    logger.warning(f"Could not apply Application model workaround: {_patch_err}")
+
 
 @mcp.tool()
 @require_scopes("okta.logs.read")


### PR DESCRIPTION
## What
Multiple Pydantic `ValidationError` failures occur when listing or retrieving applications created from the Okta App Catalog (SAML templates) and Atlassian SWA templates. The SDK's auto-generated models enforce strict field requirements that do not match the actual API responses for these app types. A single invalid record poisons the entire response page for `list_applications`, `list_applications` with `q=`/`filter=`, and `get_application`.

## Fix
Following the same pattern used for the existing `LogSecurityContext` user_behaviors workaround, we apply a monkey-patch to the `Application` model to make all fields optional and allow extra fields. This prevents the strict Pydantic validation from rejecting responses that contain fields not defined in the model or missing fields that the model expects. The fix ensures that all applications (regardless of template) can be returned without crashing on a single bad record.

Closes #48