### PR TITLE
Name upgrade of the Okta MCP Server to Okta Open Source MCP Server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Okta MCP Server Environment Variables
+# Okta Open Source MCP Server Environment Variables
 # Copy this file to .env and fill in your values
 
 # Required: Okta Organization URL (e.g., https://dev-123456.okta.com)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Summary
 This document covers how to contribute to an Okta Open Source project. These
 instructions assume you have a GitHub .com account, so if you don't have one
 you will have to create one. Your proposed code changes will be published to
-your own fork of the Okta MCP Server project and you will submit a Pull Request
+your own fork of the Okta Open Source MCP Server project and you will submit a Pull Request
 for your changes to be added.
 
 _Lets get started!!!_
@@ -32,7 +32,7 @@ the URL on the right hand side of the page under '**HTTPS** clone URL'.  You
 will paste this URL when doing the following `git clone` command.
 
 On your computer, follow these steps to setup a local repository for working on
-the Okta MCP Server:
+the Okta Open Source MCP Server:
 
 ``` bash
 $ git clone https://github.com/YOUR_ACCOUNT/okta-mcp-server.git
@@ -52,7 +52,7 @@ not change the `master` branch (other than to rebase in changes from
 changes to a branch called `feature_x`.  This `feature_x` branch will be
 created on your local repository and will be pushed to your forked repository
 on GitHub.  Once this branch is on your fork you will create a Pull Request for
-the changes to be added to the Okta MCP Server project.
+the changes to be added to the Okta Open Source MCP Server project.
 
 It is best practice to create a new branch each time you want to contribute to
 the project and only track the changes for that pull request in this branch.
@@ -109,7 +109,7 @@ Rebase `feature_x` to include updates from `upstream/master`
 
 It is important that you maintain an up-to-date `master` branch in your local
 repository.  This is done by rebasing in the code changes from
-`upstream/master` (the official Okta MCP Server project repository) into your
+`upstream/master` (the official Okta Open Source MCP Server project repository) into your
 local repository.  You will want to do this before you start working on a
 feature as well as right before you submit your changes as a pull request.  I
 recommend you do this process periodically while you work to make sure you are

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-slim
 
-LABEL Title="Okta MCP Server" \
+LABEL Title="Okta Open Source MCP Server" \
       Description="Model Context Protocol server for Okta API integration" \
       Authors="Okta" \
       Licenses="Apache-2.0" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![Okta MCP Server](https://raw.githubusercontent.com/okta/okta-mcp-server/main/assets/thumbnail.png)
+![Okta Open Source MCP Server](https://raw.githubusercontent.com/okta/okta-mcp-server/main/assets/thumbnail.png)
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python Version](https://img.shields.io/badge/python-%3E%3D3.13-brightgreen.svg)](https://python.org/)
@@ -12,7 +12,7 @@ The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you
 
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) is an open protocol introduced by Anthropic that standardizes how large language models communicate with external tools, resources or remote services.
 
-The Okta MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language. For instance, you could simply ask Claude Desktop to perform Okta management operations:
+The Okta Open Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language. For instance, you could simply ask Claude Desktop to perform Okta management operations:
 
 - > Create a new user and add them to the Engineering group
 - > Show me all failed login attempts from the last 24 hours
@@ -45,9 +45,9 @@ This MCP server utilizes [Okta's Python SDK v3.4.1](https://github.com/okta/okta
 
 <br/>
 
-### Install the Okta MCP Server
+### Install the Okta Open Source MCP Server
 
-Install Okta MCP Server and configure it to work with your preferred MCP Client.
+Install Okta Open Source MCP Server and configure it to work with your preferred MCP Client.
 
 Choose one of the following installation methods:
 
@@ -478,7 +478,7 @@ Add the following to your VS Code `settings.json`:
 <details>
 <summary><b>Other MCP Clients</b></summary>
 
-To use Okta MCP Server with any other MCP Client, you can manually add this configuration to the client and restart for changes to take effect:
+To use Okta Open Source MCP Server with any other MCP Client, you can manually add this configuration to the client and restart for changes to take effect:
 
 ```json
 {
@@ -553,7 +553,7 @@ Restart your MCP Client (Claude Desktop, VS Code, etc.) and ask it to help you m
 
 ## 🛠️ Supported Tools
 
-The Okta MCP Server provides the following tools for LLMs to interact with your Okta tenant:
+The Okta Open Source MCP Server provides the following tools for LLMs to interact with your Okta tenant:
 
 ### Users
 
@@ -752,7 +752,7 @@ All destructive operations (deleting groups, applications, policies, policy rule
 
 ## � Scope-Based Tool Loading
 
-The Okta MCP Server uses a **scope-based tool loading** mechanism to ensure that only the tools your application is authorized to use are exposed to the LLM.
+The Okta Open Source MCP Server uses a **scope-based tool loading** mechanism to ensure that only the tools your application is authorized to use are exposed to the LLM.
 
 ### How it works
 
@@ -813,7 +813,7 @@ Then restart your MCP client so the server picks up the new scope list.
 
 ## �🔐 Authentication
 
-The Okta MCP Server uses the Okta Management API and requires authentication to access your Okta tenant.
+The Okta Open Source MCP Server uses the Okta Management API and requires authentication to access your Okta tenant.
 
 ### Authentication Flow
 
@@ -834,7 +834,7 @@ The MCP Server will automatically initiate the appropriate authentication flow b
 
 ## 🩺 Troubleshooting
 
-When encountering issues with the Okta MCP Server, several troubleshooting options are available to help diagnose and resolve problems.
+When encountering issues with the Okta Open Source MCP Server, several troubleshooting options are available to help diagnose and resolve problems.
 
 ### 🐞 Debug Mode
 
@@ -935,7 +935,7 @@ uv pip install -e .
 
 ## 🔒 Security
 
-The Okta MCP Server prioritizes security:
+The Okta Open Source MCP Server prioritizes security:
 
 - Credentials are managed through secure authentication flows
 - No sensitive information is stored in plain text  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </div>
 
 ## :tada: __It's Official__ :tada:
-The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
+The Okta Open Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA).
 
 [MCP (Model Context Protocol)](https://modelcontextprotocol.io/introduction) is an open protocol introduced by Anthropic that standardizes how large language models communicate with external tools, resources or remote services.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "okta-mcp-server"
 version = "1.1.3"
-description = "The Okta Open-Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA)."
+description = "The Okta Open Source MCP Server integrates with LLMs and AI agents, allowing you to perform various Okta management operations using natural language and is Generally Available (GA)."
 readme = "README.md"
 requires-python = ">=3.13"
 license = "Apache-2.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Okta MCP Server"""
+"""Okta Open Source MCP Server"""

--- a/src/okta_mcp_server/server.py
+++ b/src/okta_mcp_server/server.py
@@ -117,7 +117,7 @@ async def get_scope_status() -> dict:
 
 
 def main():
-    """Run the Okta MCP server."""
+    """Run the Okta Open Source MCP Server."""
     logger.remove()
 
     if LOG_FILE:
@@ -134,7 +134,7 @@ def main():
         sys.stderr, level=os.environ.get("OKTA_LOG_LEVEL", "INFO"), format="{time} {level} {message}", serialize=True
     )
 
-    logger.info("Starting Okta MCP Server")
+    logger.info("Starting Okta Open Source MCP Server")
     from okta_mcp_server.tools.applications import applications  # noqa: F401
     from okta_mcp_server.tools.customization.brands import brands  # noqa: F401
     from okta_mcp_server.tools.customization.custom_domains import custom_domains  # noqa: F401

--- a/src/okta_mcp_server/tools/customization/brands/brands.py
+++ b/src/okta_mcp_server/tools/customization/brands/brands.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Brands tools for the Okta MCP server.
+"""Brands tools for the Okta Open Source MCP Server.
 
 Brands allow you to customise the Okta-hosted sign-in page, error pages,
 email templates, and the End-User Dashboard. This module exposes MCP tools

--- a/src/okta_mcp_server/tools/customization/custom_domains/custom_domains.py
+++ b/src/okta_mcp_server/tools/customization/custom_domains/custom_domains.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Custom Domains tools for the Okta MCP server.
+"""Custom Domains tools for the Okta Open Source MCP Server.
 
 Custom Domains allow you to replace the default Okta subdomain with your own
 domain name on the hosted sign-in page, error pages and email templates.

--- a/src/okta_mcp_server/tools/customization/custom_pages/custom_pages.py
+++ b/src/okta_mcp_server/tools/customization/custom_pages/custom_pages.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Custom Pages tools for the Okta MCP server.
+"""Custom Pages tools for the Okta Open Source MCP Server.
 
 Custom Pages allow you to customise the HTML content of Okta-hosted pages,
 the sign-in page widget behaviour, and the sign-out destination. This module

--- a/src/okta_mcp_server/tools/customization/custom_templates/custom_templates.py
+++ b/src/okta_mcp_server/tools/customization/custom_templates/custom_templates.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Custom Email Templates tools for the Okta MCP server.
+"""Custom Email Templates tools for the Okta Open Source MCP Server.
 
 Custom Email Templates let you localise and brand every transactional email
 Okta sends to your users.  Each template (e.g. ``UserActivation``,

--- a/src/okta_mcp_server/tools/customization/email_domains/email_domains.py
+++ b/src/okta_mcp_server/tools/customization/email_domains/email_domains.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Email Domains tools for the Okta MCP server.
+"""Email Domains tools for the Okta Open Source MCP Server.
 
 Email Domains let you customize the sender address on all transactional emails
 that Okta sends to your users.  Instead of appearing to come from an

--- a/src/okta_mcp_server/tools/customization/themes/themes.py
+++ b/src/okta_mcp_server/tools/customization/themes/themes.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Themes tools for the Okta MCP server.
+"""Themes tools for the Okta Open Source MCP Server.
 
 Themes control the visual appearance of Okta-hosted pages and email templates,
 including colours, logo, favicon, and background image. This module exposes MCP

--- a/src/okta_mcp_server/utils/elicitation.py
+++ b/src/okta_mcp_server/utils/elicitation.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Elicitation utilities for the Okta MCP server.
+"""Elicitation utilities for the Okta Open Source MCP Server.
 
 Provides shared Pydantic schemas, capability detection, and a fallback-aware
 helper for requesting user confirmation before destructive operations via the

--- a/src/okta_mcp_server/utils/scope_guard.py
+++ b/src/okta_mcp_server/utils/scope_guard.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Centralized OAuth 2.0 scope guard utilities for the Okta MCP Server.
+"""Centralized OAuth 2.0 scope guard utilities for the Okta Open Source MCP Server.
 
 This module provides the canonical scope-enforcement layer that is shared by every tool.
 It has three responsibilities:

--- a/src/okta_mcp_server/utils/scope_registry.py
+++ b/src/okta_mcp_server/utils/scope_registry.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""OAuth 2.0 scope registry for the Okta MCP Server.
+"""OAuth 2.0 scope registry for the Okta Open Source MCP Server.
 
 ``TOOL_SCOPE_REGISTRY`` is the **single source of truth** that maps every MCP
 tool name to the minimum OAuth 2.0 scope required to call it.  It is used by:

--- a/src/okta_mcp_server/utils/scope_stubs.py
+++ b/src/okta_mcp_server/utils/scope_stubs.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Scope-info stub tools for the Okta MCP Server.
+"""Scope-info stub tools for the Okta Open Source MCP Server.
 
 For each OAuth scope that is absent from ``OKTA_SCOPES``, this module registers
 exactly one lightweight stub tool. The stub appears in ``tools/list`` so the LLM

--- a/src/okta_mcp_server/utils/validation.py
+++ b/src/okta_mcp_server/utils/validation.py
@@ -6,7 +6,7 @@
 # See the License for the specific language governing permissions and limitations under the License.
 
 """
-Input validation utilities for Okta MCP Server.
+Input validation utilities for Okta Open Source MCP Server.
 
 This module provides validation functions to prevent path traversal and SSRF attacks
 by ensuring user-supplied IDs do not contain malicious characters that could manipulate

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,4 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Tests for the Okta MCP Server"""
+"""Tests for the Okta Open Source MCP Server"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-"""Shared fixtures for Okta MCP Server tests."""
+"""Shared fixtures for Okta Open Source MCP Server tests."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
 - The new name for our self-hosted MCP server is "Okta Open Source MCP Server", hence updated all the existing references from Okta MCP Server to Okta Open Source MCP Server.